### PR TITLE
Add more QAQC arrays; NetCDF update to filename convention

### DIFF
--- a/VegProcessor/configs/hsi_config_testing.yaml
+++ b/VegProcessor/configs/hsi_config_testing.yaml
@@ -21,7 +21,7 @@ simulation:
 metadata:
   model: HSI
   scenario: "05" # scenario info for plots and metadata
-  group: GXXX
+  group: G500
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/hsi_config_testing.yaml
+++ b/VegProcessor/configs/hsi_config_testing.yaml
@@ -8,7 +8,7 @@ raster_data:
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_path: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU
   salinity_raster: #str (optional)
-  veg_type_path: "/Users/dillonragar/data/cpra/VegOut_20250205_115959" # VegTransition output folder
+  veg_type_path: "/Users/dillonragar/data/cpra/AMP_VEG_S05_G504_AB_O_ANN_01_25/AMP_VEG_S05_G504_AB_O_ANN_01_25_DATA.nc" # VegTransition output folder
   flotant_marsh_raster: "/Users/dillonragar/data/cpra/AMP_lndtyp_60m_Nearest_Resample/AMP_lndtyp_60m_Nearest_Resample.tif"
   #flotant_marsh_keys: "/Users/jessicagarrett/Documents/CPRA Royal 2024/GIS/AMP_lndtyp_60m_Nearest_Resample/AMP_lndtyp_60m_Nearest_Resample.tif.vat.dbf"
 

--- a/VegProcessor/configs/hsi_config_testing.yaml
+++ b/VegProcessor/configs/hsi_config_testing.yaml
@@ -9,8 +9,7 @@ raster_data:
   wpu_path: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU
   salinity_raster: #str (optional)
   veg_type_path: "/Users/dillonragar/data/cpra/VegOut_20250205_115959" # VegTransition output folder
-  veg_type_path: "/Users/jessicagarrett/Documents/CPRA Royal 2024/GIS/data_out/VegOut_20250115_132228" # VegTransition output folder
-  flotant_marsh_raster: "/Users/jessicagarrett/Documents/CPRA Royal 2024/GIS/AMP_lndtyp_60m_Nearest_Resample/AMP_lndtyp_60m_Nearest_Resample.tif"
+  flotant_marsh_raster: "/Users/dillonragar/data/cpra/AMP_lndtyp_60m_Nearest_Resample/AMP_lndtyp_60m_Nearest_Resample.tif"
   #flotant_marsh_keys: "/Users/jessicagarrett/Documents/CPRA Royal 2024/GIS/AMP_lndtyp_60m_Nearest_Resample/AMP_lndtyp_60m_Nearest_Resample.tif.vat.dbf"
 
 simulation:

--- a/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
@@ -22,7 +22,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "S02" # scenario info for plots and metadata
-  group: G500 # TODO: double check this
+  group: G504
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
@@ -21,7 +21,7 @@ simulation:
 
 metadata: # partial list (static vars)
   model: VEG
-  scenario: "02" # scenario info for plots and metadata
+  scenario: "S02" # scenario info for plots and metadata
   group: G500 # TODO: double check this
   wpu: ARS
 

--- a/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
@@ -22,7 +22,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "02" # scenario info for plots and metadata
-  group: GXXX # TODO: double check this
+  group: G500 # TODO: double check this
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_dry.yaml
@@ -3,7 +3,7 @@
 raster_data:
   dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/2ft-slr-sequence-dry"
-  wse_domain_raster: "/Users/dillonragar/data/cpra/hecras_max_extent_domain.tif"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_grid: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU

--- a/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
@@ -22,7 +22,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "S04" # scenario info for plots and metadata
-  group: G500
+  group: G504
 
 output:
   output_base: "/Users/dillonragar/data/cpra/"

--- a/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
@@ -22,8 +22,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "04" # scenario info for plots and metadata
-  group: GXXX # TODO: double check this
-  wpu: ARS
+  group: G500
 
 output:
   output_base: "/Users/dillonragar/data/cpra/"

--- a/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
@@ -21,7 +21,7 @@ simulation:
 
 metadata: # partial list (static vars)
   model: VEG
-  scenario: "04" # scenario info for plots and metadata
+  scenario: "S04" # scenario info for plots and metadata
   group: G500
 
 output:

--- a/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_moderate.yaml
@@ -3,7 +3,7 @@
 raster_data:
   dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/2ft-slr-sequence-moderate"
-  wse_domain_raster: "/Users/dillonragar/data/cpra/hecras_max_extent_domain.tif"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_grid: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU

--- a/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
@@ -23,7 +23,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "S06" # scenario info for plots and metadata
-  group: G500
+  group: G504
   wpu: ARS
   # ion: O # identifier: input, output, internal 
 

--- a/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
@@ -22,7 +22,7 @@ simulation:
 
 metadata: # partial list (static vars)
   model: VEG
-  scenario: "06" # scenario info for plots and metadata
+  scenario: "S06" # scenario info for plots and metadata
   group: G500
   wpu: ARS
   # ion: O # identifier: input, output, internal 

--- a/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
@@ -4,7 +4,7 @@ raster_data:
   dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str
   #wse_directory_path: "/Users/dillonragar/data/tmp/cpra/AMP_SimulationResults" # must be unzipped
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/2ft-slr-sequence-wet"
-  wse_domain_raster: "/Users/dillonragar/data/cpra/hecras_max_extent_domain.tif"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_grid: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU

--- a/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
+++ b/VegProcessor/configs/veg_config_2ft_slr_wet.yaml
@@ -23,7 +23,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "06" # scenario info for plots and metadata
-  group: GXXX
+  group: G500
   wpu: ARS
   # ion: O # identifier: input, output, internal 
 

--- a/VegProcessor/configs/veg_config_base_dry.yaml
+++ b/VegProcessor/configs/veg_config_base_dry.yaml
@@ -23,7 +23,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "S01" # scenario info for plots and metadata
-  group: G500 # TODO: double check this
+  group: G504 # TODO: double check this
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_base_dry.yaml
+++ b/VegProcessor/configs/veg_config_base_dry.yaml
@@ -23,7 +23,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "01" # scenario info for plots and metadata
-  group: GXXX # TODO: double check this
+  group: G500 # TODO: double check this
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_base_dry.yaml
+++ b/VegProcessor/configs/veg_config_base_dry.yaml
@@ -3,7 +3,7 @@
 raster_data:
   dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str
   #wse_directory_path: "/Users/dillonragar/data/tmp/cpra/AMP_SimulationResults" # must be unzipped
-  wse_domain_raster: "/Users/dillonragar/data/cpra/hecras_max_extent_domain.tif"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/base-sequence-dry"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"

--- a/VegProcessor/configs/veg_config_base_dry.yaml
+++ b/VegProcessor/configs/veg_config_base_dry.yaml
@@ -22,7 +22,7 @@ simulation:
 
 metadata: # partial list (static vars)
   model: VEG
-  scenario: "01" # scenario info for plots and metadata
+  scenario: "S01" # scenario info for plots and metadata
   group: G500 # TODO: double check this
   wpu: ARS
 

--- a/VegProcessor/configs/veg_config_base_moderate.yaml
+++ b/VegProcessor/configs/veg_config_base_moderate.yaml
@@ -21,7 +21,7 @@ simulation:
 
 metadata: # partial list (static vars)
   model: VEG
-  scenario: "03" # scenario info for plots and metadata
+  scenario: "S03" # scenario info for plots and metadata
   group: G500 # TODO: double check this
   wpu: ARS
 

--- a/VegProcessor/configs/veg_config_base_moderate.yaml
+++ b/VegProcessor/configs/veg_config_base_moderate.yaml
@@ -22,7 +22,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "S03" # scenario info for plots and metadata
-  group: G500 # TODO: double check this
+  group: G504 # TODO: double check this
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_base_moderate.yaml
+++ b/VegProcessor/configs/veg_config_base_moderate.yaml
@@ -4,7 +4,7 @@ raster_data:
   dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str
   #wse_directory_path: "/Users/dillonragar/data/tmp/cpra/AMP_SimulationResults" # must be unzipped
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/base-sequence-moderate"
-  wse_domain_raster: "/Users/dillonragar/data/cpra/hecras_max_extent_domain.tif"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_grid: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU

--- a/VegProcessor/configs/veg_config_base_moderate.yaml
+++ b/VegProcessor/configs/veg_config_base_moderate.yaml
@@ -22,7 +22,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "03" # scenario info for plots and metadata
-  group: GXXX # TODO: double check this
+  group: G500 # TODO: double check this
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_base_wet.yaml
+++ b/VegProcessor/configs/veg_config_base_wet.yaml
@@ -21,7 +21,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "05" # scenario info for plots and metadata
-  group: GXXX # TODO: double check this
+  group: G500 # TODO: double check this
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_base_wet.yaml
+++ b/VegProcessor/configs/veg_config_base_wet.yaml
@@ -3,7 +3,7 @@
 raster_data:
   dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/base-sequence-wet"
-  wse_domain_raster: "/Users/dillonragar/data/cpra/hecras_max_extent_domain.tif"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_grid: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU

--- a/VegProcessor/configs/veg_config_base_wet.yaml
+++ b/VegProcessor/configs/veg_config_base_wet.yaml
@@ -20,7 +20,7 @@ simulation:
 
 metadata: # partial list (static vars)
   model: VEG
-  scenario: "05" # scenario info for plots and metadata
+  scenario: "S05" # scenario info for plots and metadata
   group: G500 # TODO: double check this
   wpu: ARS
 

--- a/VegProcessor/configs/veg_config_base_wet.yaml
+++ b/VegProcessor/configs/veg_config_base_wet.yaml
@@ -21,7 +21,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "S05" # scenario info for plots and metadata
-  group: G500 # TODO: double check this
+  group: G504 # TODO: double check this
   wpu: ARS
 
 output:

--- a/VegProcessor/configs/veg_config_testing.yaml
+++ b/VegProcessor/configs/veg_config_testing.yaml
@@ -21,7 +21,7 @@ simulation:
 
 metadata: # partial list (static vars)
   model: VEG
-  scenario: "02" # scenario info for plots and metadata
+  scenario: "S02" # scenario info for plots and metadata
   group: G500 # TODO: double check this
   wpu: AB
 

--- a/VegProcessor/configs/veg_config_testing.yaml
+++ b/VegProcessor/configs/veg_config_testing.yaml
@@ -4,7 +4,7 @@ raster_data:
   #wse_directory_path: "/Users/dillonragar/data/tmp/cpra/AMP_SimulationResults" # must be unzipped
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/2ft-slr-sequence-dry"
   #wse_directory_path: "/Users/dillonragar/data/cpra/AMP_SimulationResults/base/WY2006_base"
-  wse_domain_raster: "/Users/dillonragar/data/cpra/hecras_max_extent_domain.tif"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_grid: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU

--- a/VegProcessor/configs/veg_config_testing.yaml
+++ b/VegProcessor/configs/veg_config_testing.yaml
@@ -1,6 +1,6 @@
 # config.yaml
 raster_data:
-  dem_path: "/Users/jessicagarrett/Documents/CPRA Royal 2024/GIS/DEM/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str"
+  dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str"
   #wse_directory_path: "/Users/dillonragar/data/tmp/cpra/AMP_SimulationResults" # must be unzipped
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/2ft-slr-sequence-dry"
   #wse_directory_path: "/Users/dillonragar/data/cpra/AMP_SimulationResults/base/WY2006_base"

--- a/VegProcessor/configs/veg_config_testing.yaml
+++ b/VegProcessor/configs/veg_config_testing.yaml
@@ -22,7 +22,7 @@ simulation:
 metadata: # partial list (static vars)
   model: VEG
   scenario: "02" # scenario info for plots and metadata
-  group: GXXX # TODO: double check this
+  group: G500 # TODO: double check this
   wpu: AB
 
 

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -647,6 +647,7 @@ class HSI(vt.VegTransition):
                 )
 
             # assign values for timestep
+            # not dtype rules needed here as 480m cell is light
             ds[var_name].loc[{"time": timestep_str}] = data
 
         ds.close()

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -258,9 +258,9 @@ class HSI(vt.VegTransition):
         # run HSI models for timestep
         if self.run_hsi:
 
-            self.alligator = alligator.AlligatorHSI.from_hsi(self)
+            # self.alligator = alligator.AlligatorHSI.from_hsi(self)
             self.crawfish = crawfish.CrawfishHSI.from_hsi(self)
-            self.baldeagle = baldeagle.BaldEagleHSI.from_hsi(self)
+            # self.baldeagle = baldeagle.BaldEagleHSI.from_hsi(self)
             # self.black_bear = BlackBearHSI(self)
 
             self._append_hsi_vars_to_netcdf(timestep=self.current_timestep)
@@ -300,7 +300,7 @@ class HSI(vt.VegTransition):
             a single WY, defined by `self.current_timestep`.
         """
         logging.info("Loading vegetation data.")
-        file_path = os.path.join(self.veg_type_path, "data_output.nc")
+        file_path = os.path.join(self.veg_type_path)
         time_str = self.current_timestep.strftime("%Y%m%d")
         ds = xr.open_dataset(file_path)
         da = ds.sel({"time": time_str})["veg_type"]

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -568,7 +568,7 @@ class HSI(vt.VegTransition):
         self._logger.info("Initialized NetCDF file: %s", self.netcdf_filepath)
 
     def _append_hsi_vars_to_netcdf(self, timestep: pd.DatetimeTZDtype):
-        """BETA Append timestep data to the NetCDF file.
+        """Append timestep data to the NetCDF file.
 
         Parameters
         ----------

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -241,8 +241,12 @@ class HSI(vt.VegTransition):
         self.wse = self.load_wse_wy(wy, variable_name="WSE_MEAN")
         self.wse = self._reproject_match_to_dem(self.wse)  # TEMPFIX
         self.water_depth_annual_mean = self._get_water_depth_annual_mean()
-        # self.water_depth_monthly_mean_jan_aug = self._get_water_depth_monthly_mean_jan_aug()
-        # self.water_depth_monthly_mean_sept_dec = self._get_water_depth_monthly_mean_sept_dec()
+        self.water_depth_monthly_mean_jan_aug = (
+            self._get_water_depth_monthly_mean_jan_aug()
+        )
+        self.water_depth_monthly_mean_sept_dec = (
+            self._get_water_depth_monthly_mean_sept_dec()
+        )
 
         # load veg type
         self.veg_type = self._load_veg_type()

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -258,9 +258,9 @@ class HSI(vt.VegTransition):
         # run HSI models for timestep
         if self.run_hsi:
 
-            # self.alligator = alligator.AlligatorHSI.from_hsi(self)
+            self.alligator = alligator.AlligatorHSI.from_hsi(self)
             self.crawfish = crawfish.CrawfishHSI.from_hsi(self)
-            # self.baldeagle = baldeagle.BaldEagleHSI.from_hsi(self)
+            self.baldeagle = baldeagle.BaldEagleHSI.from_hsi(self)
             # self.black_bear = BlackBearHSI(self)
 
             self._append_hsi_vars_to_netcdf(timestep=self.current_timestep)

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -83,9 +83,9 @@ class HSI(vt.VegTransition):
 
         # metadata
         self.metadata = self.config["metadata"]
-        self.scenario_type = self.config["metadata"].get(
-            "scenario", ""
-        )  # empty str if missing
+        # self.scenario_type = self.config["metadata"].get(
+        #     "scenario", ""
+        # )  # empty str if missing
 
         # output
         self.output_base_dir = self.config["output"].get("output_base")

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -300,9 +300,8 @@ class HSI(vt.VegTransition):
             a single WY, defined by `self.current_timestep`.
         """
         logging.info("Loading vegetation data.")
-        file_path = os.path.join(self.veg_type_path)
         time_str = self.current_timestep.strftime("%Y%m%d")
-        ds = xr.open_dataset(file_path)
+        ds = xr.open_dataset(self.veg_type_path)
         da = ds.sel({"time": time_str})["veg_type"]
         return da
 

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -241,6 +241,7 @@ class HSI(vt.VegTransition):
         self.wse = self.load_wse_wy(wy, variable_name="WSE_MEAN")
         self.wse = self._reproject_match_to_dem(self.wse)  # TEMPFIX
         self.water_depth_annual_mean = self._get_water_depth_annual_mean()
+
         self.water_depth_monthly_mean_jan_aug = (
             self._get_water_depth_monthly_mean_jan_aug()
         )

--- a/VegProcessor/run.ipynb
+++ b/VegProcessor/run.ipynb
@@ -142,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Veg = VegTransition(config_file=\"./configs/veg_config_base_wet.yaml\")"
+    "Veg = VegTransition(config_file=\"./configs/veg_config_testing.yaml\")"
    ]
   },
   {
@@ -152,7 +152,7 @@
    "outputs": [],
    "source": [
     "Veg.run()\n",
-    "Veg.post_process()"
+    "# Veg.post_process()"
    ]
   },
   {
@@ -252,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HSI.alligator.hsi"
+    "HSI"
    ]
   },
   {

--- a/VegProcessor/species_hsi/crawfish.py
+++ b/VegProcessor/species_hsi/crawfish.py
@@ -156,7 +156,8 @@ class CrawfishHSI:
 
         else:
             self._logger.info("Running SI 2")
-            si_2 = np.full(self._shape, 999.0)
+            # template array with NaN for HH domain
+            si_2 = np.where(np.isnan(self.v2_mean_water_depth_jan_aug), np.nan, 999.0)
 
             # condition 1 (OR)
             mask_1 = (self.v2_mean_water_depth_jan_aug <= 0.0) | (
@@ -229,7 +230,9 @@ class CrawfishHSI:
 
         else:
             self._logger.info("Running SI 4")
-            si_4 = np.full(self._shape, 999.0)
+            # if input var array has NaN, only valid data should be set
+            # (and then checked) for 999.0
+            si_4 = np.where(np.isnan(self.v4_mean_water_depth_sept_dec), np.nan, 999.0)
 
             # condition 1
             mask_1 = self.v4_mean_water_depth_sept_dec <= 0.0  # RHS is in meters

--- a/VegProcessor/species_hsi/crawfish.py
+++ b/VegProcessor/species_hsi/crawfish.py
@@ -18,7 +18,7 @@ class CrawfishHSI:
     # init with None to be distinct from np.nan
     v1_mean_annual_salinity: np.ndarray = None
     v2_mean_water_depth_jan_aug: np.ndarray = None
-    #v3_pct_cell_covered_by_habitat_types: np.ndarray = None
+    # v3_pct_cell_covered_by_habitat_types: np.ndarray = None
     v3a_pct_cell_swamp_bottomland_hardwood: np.ndarray = None
     v3b_pct_cell_fresh_marsh: np.ndarray = None
     v3c_pct_cell_open_water: np.ndarray = None
@@ -48,15 +48,15 @@ class CrawfishHSI:
         """Create CrawfishHSI instance from an HSI instance."""
         return cls(
             v1_mean_annual_salinity=hsi_instance.mean_annual_salinity,
-            v2_mean_water_depth_jan_aug=hsi_instance.water_depth_monthly_mean_jan_aug, #NEW
+            v2_mean_water_depth_jan_aug=hsi_instance.water_depth_monthly_mean_jan_aug,  # NEW
             v3a_pct_cell_swamp_bottomland_hardwood=hsi_instance.pct_swamp_bottom_hardwood,
             v3b_pct_cell_fresh_marsh=hsi_instance.pct_fresh_marsh,
-            v3c_pct_cell_open_water=hsi_instance.pct_open_water, #many already in hsi "superclass" use same RHS
+            v3c_pct_cell_open_water=hsi_instance.pct_open_water,  # many already in hsi "superclass" use same RHS
             v3d_pct_cell_intermediate_marsh=hsi_instance.pct_intermediate_marsh,
             v3e_pct_cell_brackish_marsh=hsi_instance.pct_brackish_marsh,
-            v3f_pct_cell_saline_marsh=hsi_instance.pct_saline_marsh, #NEW #23
-            v3g_pct_cell_bare_ground=hsi_instance.pct_bare_ground, #NEW
-            v4_mean_water_depth_sept_dec=hsi_instance.water_depth_monthly_mean_sept_dec, #NEW
+            v3f_pct_cell_saline_marsh=hsi_instance.pct_saline_marsh,  # NEW #23
+            v3g_pct_cell_bare_ground=hsi_instance.pct_bare_ground,  # NEW
+            v4_mean_water_depth_sept_dec=hsi_instance.water_depth_monthly_mean_sept_dec,  # NEW
         )
 
     def __post_init__(self):
@@ -111,7 +111,9 @@ class CrawfishHSI:
     def calculate_si_1(self) -> np.ndarray:
         """Mean annual salinity."""
         if self.v1_mean_annual_salinity is None:
-            self._logger.info("mean annual salinity data not provided. Setting index to 1.")
+            self._logger.info(
+                "mean annual salinity data not provided. Setting index to 1."
+            )
             si_1 = np.ones(self._shape)
 
         else:
@@ -124,11 +126,15 @@ class CrawfishHSI:
             si_1[mask_1] = 1.0
 
             # condition 2 (AND)
-            mask_2 = (self.v1_mean_annual_salinity > 1.5) & (self.v1_mean_annual_salinity <= 3.0)
+            mask_2 = (self.v1_mean_annual_salinity > 1.5) & (
+                self.v1_mean_annual_salinity <= 3.0
+            )
             si_1[mask_2] = 1.5 - (0.333 * self.v1_mean_annual_salinity[mask_2])
 
             # condition 3 (AND)
-            mask_3 = (self.v1_mean_annual_salinity > 3.0) & (self.v1_mean_annual_salinity <= 6.0)
+            mask_3 = (self.v1_mean_annual_salinity > 3.0) & (
+                self.v1_mean_annual_salinity <= 6.0
+            )
             si_1[mask_3] = 1.0 - (0.167 * self.v1_mean_annual_salinity[mask_3])
 
             # condition 4
@@ -154,7 +160,7 @@ class CrawfishHSI:
 
             # condition 1 (OR)
             mask_1 = (self.v2_mean_water_depth_jan_aug <= 0.0) | (
-                self.v2_mean_water_depth_jan_aug > 2.74 #RHS is in meters
+                self.v2_mean_water_depth_jan_aug > 2.74  # RHS is in meters
             )
             si_2[mask_1] = 0.0
 
@@ -184,7 +190,7 @@ class CrawfishHSI:
     def calculate_si_3(self) -> np.ndarray:
         """Proportion of cell covered by habitat types."""
         self._logger.info("Running SI 3")
-        
+
         for array in [
             self.v3a_pct_cell_swamp_bottomland_hardwood,
             self.v3b_pct_cell_fresh_marsh,
@@ -195,17 +201,20 @@ class CrawfishHSI:
             self.v3g_pct_cell_bare_ground,
         ]:
             if array is None:
-                self._logger.info("Pct habitat types data not provided. Setting index to 1", array)
+                self._logger.info(
+                    "Pct habitat types data not provided. Setting index to 1", array
+                )
                 array = np.ones(self._shape)
 
         # easier to just do % here, hence /100
-        si_3 = ((1.0 * (self.v3a_pct_cell_swamp_bottomland_hardwood/100)) + 
-            (0.85 * (self.v3b_pct_cell_fresh_marsh/100)) + 
-            (0.75 * (self.v3c_pct_cell_open_water/100)) + 
-            (0.6 * (self.v3d_pct_cell_intermediate_marsh/100)) +
-            (0.2 * (self.v3e_pct_cell_brackish_marsh/100)) +
-            (0.0 * (self.v3f_pct_cell_saline_marsh/100)) + 
-            (0.0 * (self.v3g_pct_cell_bare_ground/100))
+        si_3 = (
+            (1.0 * (self.v3a_pct_cell_swamp_bottomland_hardwood / 100))
+            + (0.85 * (self.v3b_pct_cell_fresh_marsh / 100))
+            + (0.75 * (self.v3c_pct_cell_open_water / 100))
+            + (0.6 * (self.v3d_pct_cell_intermediate_marsh / 100))
+            + (0.2 * (self.v3e_pct_cell_brackish_marsh / 100))
+            + (0.0 * (self.v3f_pct_cell_saline_marsh / 100))
+            + (0.0 * (self.v3g_pct_cell_bare_ground / 100))
         )
         # TODO: error handling here? (for case where no blank arr is initialized)
         return si_3
@@ -223,7 +232,7 @@ class CrawfishHSI:
             si_4 = np.full(self._shape, 999)
 
             # condition 1
-            mask_1 = (self.v4_mean_water_depth_sept_dec <= 0.0) #RHS is in meters
+            mask_1 = self.v4_mean_water_depth_sept_dec <= 0.0  # RHS is in meters
             si_4[mask_1] = 1.0
 
             # condition 2 (AND)
@@ -232,15 +241,14 @@ class CrawfishHSI:
             )
             si_4[mask_2] = 1.0 - (0.06667 * self.v4_mean_water_depth_sept_dec[mask_2])
 
-            # condition 3 
-            mask_3 = (self.v4_mean_water_depth_sept_dec > 0.15)
+            # condition 3
+            mask_3 = self.v4_mean_water_depth_sept_dec > 0.15
             si_4[mask_3] = 0.0
 
             if 999 in si_4:
                 raise ValueError("Unhandled condition in SI logic!")
 
         return si_4
-    
 
     def calculate_overall_suitability(self) -> np.ndarray:
         """Combine individual suitability indices to compute the overall HSI with quality control."""
@@ -261,7 +269,9 @@ class CrawfishHSI:
                 )
 
         # Combine individual suitability indices
-        hsi = ((self.si_1 * self.si_2) ** 1/6) * (self.si_3 ** 1/3) * (self.si_4 ** 1/3)
+        hsi = (
+            ((self.si_1 * self.si_2) ** 1 / 6) * (self.si_3**1 / 3) * (self.si_4**1 / 3)
+        )
 
         # Quality control check: Ensure combined_score is between 0 and 1
         invalid_values = (hsi < 0) | (hsi > 1)

--- a/VegProcessor/species_hsi/crawfish.py
+++ b/VegProcessor/species_hsi/crawfish.py
@@ -119,7 +119,7 @@ class CrawfishHSI:
         else:
             self._logger.info("Running SI 1")
             # Create an array to store the results
-            si_1 = np.full(self._shape, 999)
+            si_1 = np.full(self._shape, 999.0)
 
             # condition 1
             mask_1 = self.v1_mean_annual_salinity <= 1.5
@@ -141,7 +141,7 @@ class CrawfishHSI:
             mask_4 = self.v1_mean_annual_salinity > 6.0
             si_1[mask_4] = 0.0
 
-            if 999 in si_1:
+            if np.any(np.isclose(si_1, 999.0, atol=1e-5)):
                 raise ValueError("Unhandled condition in SI logic!")
 
         return si_1
@@ -156,7 +156,7 @@ class CrawfishHSI:
 
         else:
             self._logger.info("Running SI 2")
-            si_2 = np.full(self._shape, 999)
+            si_2 = np.full(self._shape, 999.0)
 
             # condition 1 (OR)
             mask_1 = (self.v2_mean_water_depth_jan_aug <= 0.0) | (
@@ -182,7 +182,7 @@ class CrawfishHSI:
             )
             si_2[mask_4] = 1.5 - (0.00457 * self.v2_mean_water_depth_jan_aug[mask_4])
 
-            if 999 in si_2:
+            if np.any(np.isclose(si_2, 999.0, atol=1e-5)):
                 raise ValueError("Unhandled condition in SI logic!")
 
         return si_2
@@ -229,7 +229,7 @@ class CrawfishHSI:
 
         else:
             self._logger.info("Running SI 4")
-            si_4 = np.full(self._shape, 999)
+            si_4 = np.full(self._shape, 999.0)
 
             # condition 1
             mask_1 = self.v4_mean_water_depth_sept_dec <= 0.0  # RHS is in meters
@@ -245,7 +245,7 @@ class CrawfishHSI:
             mask_3 = self.v4_mean_water_depth_sept_dec > 0.15
             si_4[mask_3] = 0.0
 
-            if 999 in si_4:
+            if np.any(np.isclose(si_4, 999.0, atol=1e-5)):
                 raise ValueError("Unhandled condition in SI logic!")
 
         return si_4

--- a/VegProcessor/test.py
+++ b/VegProcessor/test.py
@@ -61,7 +61,7 @@ class TestZoneV(unittest.TestCase):
             veg_type=self.veg_type,
             water_depth=self.water_depth,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -127,7 +127,7 @@ class TestZoneIV(unittest.TestCase):
             veg_type=self.veg_type,
             water_depth=self.water_depth,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -193,7 +193,7 @@ class TestZoneIII(unittest.TestCase):
             veg_type=self.veg_type,
             water_depth=self.water_depth,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -299,7 +299,7 @@ class TestZoneII(unittest.TestCase):
             veg_type=self.veg_type,
             water_depth=self.water_depth,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -392,7 +392,7 @@ class TestFreshShrub(unittest.TestCase):
             veg_type=self.veg_type,
             water_depth=self.water_depth,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -503,7 +503,7 @@ class TestFreshMarsh(unittest.TestCase):
             water_depth=self.water_depth,
             salinity=self.salinity,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -628,7 +628,7 @@ class TestIntermediateMarsh(unittest.TestCase):
             water_depth=self.water_depth,
             salinity=self.salinity,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -753,7 +753,7 @@ class TestBrackishMarsh(unittest.TestCase):
             water_depth=self.water_depth,
             salinity=self.salinity,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -878,7 +878,7 @@ class TestSalineMarsh(unittest.TestCase):
             water_depth=self.water_depth,
             salinity=self.salinity,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,
@@ -1016,7 +1016,7 @@ class TestWater(unittest.TestCase):
             water_depth=self.water_depth,
             salinity=self.salinity,
             timestep_output_dir="~/data/tmp/scratch/",
-        )
+        )["veg_type"]
 
         np.testing.assert_array_equal(
             correct_result,

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -433,8 +433,7 @@ def open_veg_multifile(veg_base_path: str) -> xr.Dataset:
 
     Returns:
     --------
-        (xr.Dataset) with expanded *placeholder* time dimension.
-
+        (xr.Dataset) with time dimension.
     """
     dates = os.listdir(veg_base_path)
     dates = [
@@ -465,7 +464,7 @@ def pixel_sums_full_domain(ds: xr.Dataset) -> pd.DataFrame:
     # Use Xarray to count occurrences of each unique value
     # Create a DataArray mask for all unique values at once
     mask = xr.concat(
-        [(ds["band_data"] == value) for value in unique_values], dim="value"
+        [(ds["veg_type"] == value) for value in unique_values], dim="value"
     )
     # Assign unique values as a coordinate to the new dimension
     mask = mask.assign_coords(value=("value", unique_values))
@@ -506,7 +505,7 @@ def wpu_sums(ds_veg: xr.Dataset, zones: xr.DataArray) -> pd.DataFrame:
     df_list = []
 
     for t in ds_veg.time.values:
-        veg_2d = ds_veg["band_data"].sel(time=t)
+        veg_2d = ds_veg["veg_type"].sel(time=t)
 
         # Convert the dask-backed DataArrays to NumPy
         veg_2d_np = veg_2d.compute()
@@ -519,7 +518,7 @@ def wpu_sums(ds_veg: xr.Dataset, zones: xr.DataArray) -> pd.DataFrame:
     df_out = pd.concat(df_list)
     df_out.rename(columns={"zone": "wpu"}, inplace=True)
     df_out["wpu"] = df_out["wpu"].astype(int)
-    df_out.drop(columns=0, inplace=True)
+    # df_out.drop(columns=0, inplace=True)
 
     return df_out
 

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -526,23 +526,22 @@ def wpu_sums(ds_veg: xr.Dataset, zones: xr.DataArray) -> pd.DataFrame:
 def generate_filename(params: dict, parameter: str, base_path: str = None) -> Path:
     """
     Generate a filename based on the Atchafalaya Master Plan (AMP) file naming convention.
+    Missing parameters are skipped.
 
     Parameters:
     -----------
     params : dict
-        Dictionary containing the following keys:
+        Dictionary containing optional keys:
         - model : str
         - scenario : str
         - group : str
         - wpu : str
         - io_type : str
-        - time_frame : str
+        - time_freq : str
         - year_range : str
         This dict is created in `VegTransition.step` and includes metadata from the
-        current timestep as well as the model config file. It excludes, "parameter"
-        wich is a required arg, and specified only when this function is called so
-        that the same timestep params dict can be used for different output
-        "parameters".
+        current timestep as well as the model config file. It excludes "parameter",
+        which is specified separately.
 
     parameter : str
         The name of the variable being saved, i.e. "VEGTYPE".
@@ -555,8 +554,8 @@ def generate_filename(params: dict, parameter: str, base_path: str = None) -> Pa
     Path
         A `Path` object representing the full path to the generated file.
     """
-    # Ensure keys are provided in the dictionary
-    required_keys = [
+    # Define the order of keys
+    key_order = [
         "model",
         "scenario",
         "group",
@@ -565,26 +564,86 @@ def generate_filename(params: dict, parameter: str, base_path: str = None) -> Pa
         "time_freq",
         "year_range",
     ]
-    for key in required_keys:
-        if key not in params:
-            raise ValueError(f"Missing required key: '{key}' in params dictionary")
 
-    # Extract and process the values
-    model = params["model"].upper()
-    scenario = params["scenario"]
-    group = params["group"]
-    wpu = params["wpu"]
-    io_type = params["io_type"].upper()
-    time_freq = params["time_freq"].upper()
-    year_range = params["year_range"]
+    # Collect available values from params in order
+    values = [
+        params[key].upper() if isinstance(params.get(key), str) else params.get(key)
+        for key in key_order
+        if key in params and params[key] is not None
+    ]
 
-    # file_extension = params["file_extension"].lower()
+    # Append parameter to the filename
+    values.append(parameter)
 
     # Construct the filename
-    filename = f"AMP_{model}_{scenario}_{group}_{wpu}_{io_type}_{time_freq}_{year_range}_{parameter}"
+    filename = "AMP_" + "_".join(map(str, values))
 
     # Combine with base path if provided
-    if base_path:
-        return Path(base_path) / filename
-    else:
-        return Path(filename)
+    return Path(base_path) / filename if base_path else Path(filename)
+
+
+# def generate_filename(params: dict, parameter: str, base_path: str = None) -> Path:
+#     """
+#     Generate a filename based on the Atchafalaya Master Plan (AMP) file naming convention.
+
+#     Parameters:
+#     -----------
+#     params : dict
+#         Dictionary containing the following keys:
+#         - model : str
+#         - scenario : str
+#         - group : str
+#         - wpu : str
+#         - io_type : str
+#         - time_frame : str
+#         - year_range : str
+#         This dict is created in `VegTransition.step` and includes metadata from the
+#         current timestep as well as the model config file. It excludes, "parameter"
+#         wich is a required arg, and specified only when this function is called so
+#         that the same timestep params dict can be used for different output
+#         "parameters".
+
+#     parameter : str
+#         The name of the variable being saved, i.e. "VEGTYPE".
+
+#     base_path : str or Path, optional
+#         Base directory path where the file should be located.
+
+#     Returns:
+#     --------
+#     Path
+#         A `Path` object representing the full path to the generated file.
+#     """
+#     # Ensure keys are provided in the dictionary
+#     required_keys = [
+#         "model",
+#         "scenario",
+#         "group",
+#         "wpu",
+#         "io_type",
+#         "time_freq",
+#         "year_range",
+#     ]
+#     for key in required_keys:
+#         if key not in params:
+#             raise ValueError(f"Missing required key: '{key}' in params dictionary")
+
+#     # Extract and process the values
+#     model = params["model"].upper()
+#     scenario = params["scenario"]
+#     group = params["group"]
+#     wpu = params["wpu"]
+#     io_type = params["io_type"].upper()
+#     time_freq = params["time_freq"].upper()
+#     year_range = params["year_range"]
+
+#     # file_extension = params["file_extension"].lower()
+
+#     # Construct the filename
+#     filename = f"AMP_{model}_{scenario}_{group}_{wpu}_{io_type}_{time_freq}_{year_range}_{parameter}"
+
+#     # Combine with base path if provided
+#     if base_path:
+#         return Path(base_path) / filename
+#     else:
+#         return Path(filename)

--- a/VegProcessor/veg_logic.py
+++ b/VegProcessor/veg_logic.py
@@ -102,14 +102,14 @@ def zone_v(
     )
 
     # create output dict
-    out = {
+    data_out = {
         "veg_type": veg_type,
         "condition_1": condition_1,
         "condition_2": condition_2,
     }
 
     logger.info("Finished transitions with input type: Zone V")
-    return out
+    return data_out
 
 
 def zone_iv(
@@ -213,9 +213,15 @@ def zone_iv(
         out_path=timestep_output_dir,
     )
 
-    logger.info("Finished transitions with input type: Zone IV")
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+        "condition_3": condition_3,
+    }
 
-    return veg_type
+    logger.info("Finished transitions with input type: Zone IV")
+    return data_out
 
 
 def zone_iii(

--- a/VegProcessor/veg_logic.py
+++ b/VegProcessor/veg_logic.py
@@ -327,8 +327,15 @@ def zone_iii(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+        "condition_3": condition_3,
+    }
+
     logger.info("Finished transitions with input type: Zone III")
-    return veg_type
+    return data_out
 
 
 def zone_ii(
@@ -441,8 +448,16 @@ def zone_ii(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+        "condition_3": condition_3,
+        "condition_4": condition_4,
+    }
+
     logger.info("Finished transitions with input type: Zone II")
-    return veg_type
+    return data_out
 
 
 def fresh_shrub(
@@ -551,8 +566,15 @@ def fresh_shrub(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+        "condition_3": condition_3,
+    }
+
     logger.info("Finished transitions with input type: Fresh Shrub")
-    return veg_type
+    return data_out
 
 
 def fresh_marsh(
@@ -686,8 +708,16 @@ def fresh_marsh(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+        "condition_3": condition_3,
+        "condition_4": condition_4,
+    }
+
     logger.info("Finished transitions with input type: Fresh Marsh")
-    return veg_type
+    return data_out
 
 
 def intermediate_marsh(
@@ -816,8 +846,15 @@ def intermediate_marsh(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+        "condition_3": condition_3,
+    }
+
     logger.info("Finished transitions with input type: Intermediate Marsh")
-    return veg_type
+    return data_out
 
 
 def brackish_marsh(
@@ -949,8 +986,15 @@ def brackish_marsh(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+        "condition_3": condition_3,
+    }
+
     logger.info("Finished transitions with input type: Brackish Marsh")
-    return veg_type
+    return data_out
 
 
 def saline_marsh(
@@ -1059,8 +1103,14 @@ def saline_marsh(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+    }
+
     logger.info("Finished transitions with input type: Saline Marsh")
-    return veg_type
+    return data_out
 
 
 def water(
@@ -1213,5 +1263,13 @@ def water(
         out_path=timestep_output_dir,
     )
 
+    data_out = {
+        "veg_type": veg_type,
+        "condition_1_3_5_7": condition_1_3_5_7,
+        "condition_2": condition_2,
+        "condition_4": condition_4,
+        "condition_6": condition_6,
+    }
+
     logger.info("Finished transitions with input type: Water")
-    return veg_type
+    return data_out

--- a/VegProcessor/veg_logic.py
+++ b/VegProcessor/veg_logic.py
@@ -101,8 +101,15 @@ def zone_v(
         out_path=timestep_output_dir,
     )
 
+    # create output dict
+    out = {
+        "veg_type": veg_type,
+        "condition_1": condition_1,
+        "condition_2": condition_2,
+    }
+
     logger.info("Finished transitions with input type: Zone V")
-    return veg_type
+    return out
 
 
 def zone_iv(
@@ -581,7 +588,7 @@ def fresh_marsh(
     # clone input
     veg_type, veg_type_input = veg_type.copy(), veg_type.copy()
     apr_sep = [4, 5, 6, 7, 8, 9]
-    #mar_june = [3, 4, 5, 6]
+    # mar_june = [3, 4, 5, 6]
     gs = [4, 5, 6, 7, 8, 9]
 
     # Subset for veg type Fresh Marsh (value 20)
@@ -645,7 +652,7 @@ def fresh_marsh(
         [
             combined_mask_water,
             combined_mask_intermediate_marsh,
-            combined_mask_fresh_shrub
+            combined_mask_fresh_shrub,
         ]
     )
 

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -260,12 +260,20 @@ class VegTransition:
         self._logger.info("Masking veg type array to domain.")
         self.veg_type = np.where(self.hecras_domain, self.veg_type, np.nan)
 
-        # veg_type array is iteratively updated, for each zone
-        self.veg_type_update_1 = veg_logic.zone_v(
+        # # brainstorm for saving condition arrays
+        self.zone_v = veg_logic.zone_v(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
         )
+        self.veg_type_update_1 = self.zone_v["veg_type"]
+
+        # # veg_type array is iteratively updated, for each zone
+        # self.veg_type_update_1 = veg_logic.zone_v(
+        #     self.veg_type,
+        #     self.water_depth,
+        #     self.timestep_output_dir_figs,
+        # )
         self.veg_type_update_2 = veg_logic.zone_iv(
             self.veg_type,
             self.water_depth,
@@ -800,6 +808,10 @@ class VegTransition:
                     ["time", "y", "x"],
                     np.full((len(time_range), len(y), len(x)), np.nan),
                 ),
+                "zone_v_condition_1": (
+                    ["time", "y", "x"],
+                    np.full((len(time_range), len(y), len(x)), np.nan),
+                ),
             },
             coords={"time": time_range, "y": y, "x": x},
         )
@@ -837,6 +849,11 @@ class VegTransition:
         # Modify in-memory dataset
         ds["veg_type"].loc[{"time": timestep_str}] = self.veg_type
         ds["maturity"].loc[{"time": timestep_str}] = self.maturity
+
+        # testing
+        ds["zone_v_condition_1"].loc[{"time": timestep_str}] = self.zone_v[
+            "condition_1"
+        ]
 
         ds.close()
         # Write back to file

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -153,6 +153,8 @@ class VegTransition:
         # self.pct_no_mast = template
 
         # NetCDF data output
+        sim_length = self.water_year_start - self.water_year_end
+
         file_params = {
             "model": self.metadata.get("model"),
             "scenario": self.metadata.get("scenario"),
@@ -160,7 +162,7 @@ class VegTransition:
             "wpu": "AB",
             "io_type": "O",
             "time_freq": "ANN",  # for annual output
-            # "year_range": f"{counter.zfill(2)}_{simulation_period.zfill(2)}",
+            "year_range": f"01_{sim_length.zfill(2)}",
             # "parameter": "NA",  # ?
         }
 

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -153,7 +153,7 @@ class VegTransition:
         # self.pct_no_mast = template
 
         # NetCDF data output
-        sim_length = self.water_year_start - self.water_year_end
+        sim_length = self.water_year_end - self.water_year_start
 
         file_params = {
             "model": self.metadata.get("model"),
@@ -162,7 +162,7 @@ class VegTransition:
             "wpu": "AB",
             "io_type": "O",
             "time_freq": "ANN",  # for annual output
-            "year_range": f"01_{sim_length.zfill(2)}",
+            "year_range": f"01_{str(sim_length + 1).zfill(2)}",
             # "parameter": "NA",  # ?
         }
 
@@ -786,7 +786,18 @@ class VegTransition:
             print("Config file not found at %s", self.config_path)
 
     def _create_output_file(self, params: dict):
-        """Create NetCDF file for data output."""
+        """VegTransition: Create NetCDF file for data output.
+
+        Parameters
+        ----------
+        params : dict
+            Dict of filename attributes, specified in
+            `utils.generate_filename()`
+
+        Returns
+        -------
+        None
+        """
 
         file_name = utils.generate_filename(
             params=params,

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -388,7 +388,7 @@ class VegTransition:
         # serialize state variables: veg_type, maturity, mast %
         self._logger.info("saving state variables for timestep.")
         # self._save_state_vars(params)
-        self._append_to_netcdf(timestep=self.current_timestep)
+        self._append_veg_vars_to_netcdf(timestep=self.current_timestep)
 
         self._logger.info("completed timestep: %s", timestep)
         self.current_timestep = None

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -750,6 +750,7 @@ class VegTransition:
         da = da.squeeze(drop="band")
         # reproject match to DEM
         da = self._reproject_match_to_dem(da)
+        da = da.fillna(0)  # fill 0 so that .astype(bool) does not fail
         da = da.astype(bool)
         return da.to_numpy()
 

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -977,7 +977,9 @@ class VegTransition:
         wpu = wpu["band" == 0]
         # Replace 0 with NaN (Zone 0 is outside of all WPU polygons)
         wpu = xr.where(wpu != 0, wpu, np.nan)
-        ds = utils.open_veg_multifile(self.output_dir_path)
+
+        ds = xr.open_dataset(self.netcdf_filepath)
+        # ds = utils.open_veg_multifile(self.output_dir_path)
 
         logging.info("Calculating WPU veg type sums.")
         df = utils.wpu_sums(ds_veg=ds, zones=wpu)

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -153,7 +153,18 @@ class VegTransition:
         # self.pct_no_mast = template
 
         # NetCDF data output
-        self._create_output_file()
+        file_params = {
+            "model": self.metadata.get("model"),
+            "scenario": self.metadata.get("scenario"),
+            "group": self.metadata.get("group"),  # not sure if this is correct,
+            "wpu": "AB",
+            "io_type": "O",
+            "time_freq": "ANN",  # for annual output
+            # "year_range": f"{counter.zfill(2)}_{simulation_period.zfill(2)}",
+            # "parameter": "NA",  # ?
+        }
+
+        self._create_output_file(file_params)
 
     def _setup_logger(self, log_level=logging.INFO):
         """Set up the logger for the VegTransition class."""
@@ -369,16 +380,16 @@ class VegTransition:
 
         self._calculate_maturity(veg_type_in)
 
-        params = {
-            "model": self.metadata.get("model"),
-            "scenario": self.metadata.get("scenario"),
-            "group": self.metadata.get("group"),  # not sure if this is correct,
-            "wpu": "AB",
-            "io_type": "O",
-            "time_freq": "ANN",  # for annual output
-            "year_range": f"{counter.zfill(2)}_{simulation_period.zfill(2)}",
-            "parameter": "NA",  # ?
-        }
+        # params = {
+        #     "model": self.metadata.get("model"),
+        #     "scenario": self.metadata.get("scenario"),
+        #     "group": self.metadata.get("group"),  # not sure if this is correct,
+        #     "wpu": "AB",
+        #     "io_type": "O",
+        #     "time_freq": "ANN",  # for annual output
+        #     "year_range": f"{counter.zfill(2)}_{simulation_period.zfill(2)}",
+        #     "parameter": "NA",  # ?
+        # }
 
         # serialize state variables: veg_type, maturity, mast %
         self._logger.info("saving state variables for timestep.")
@@ -772,9 +783,16 @@ class VegTransition:
         else:
             print("Config file not found at %s", self.config_path)
 
-    def _create_output_file(self):
+    def _create_output_file(self, params: dict):
         """Create NetCDF file for data output."""
-        self.netcdf_filepath = os.path.join(self.output_dir_path, "data_output.nc")
+
+        file_name = utils.generate_filename(
+            params=params,
+            base_path=self.timestep_output_dir,
+            parameter="DATA",
+        )
+
+        self.netcdf_filepath = os.path.join(self.output_dir_path, f"{file_name}.nc")
 
         # load DEM, use coords
         da = xr.open_dataarray(self.dem_path)

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -794,29 +794,6 @@ class VegTransition:
         ds = xr.Dataset(coords={"time": time_range, "y": y, "x": x})
         ds = ds.rio.write_crs("EPSG:6344")
 
-        # # Create a new Dataset with dimensions (time, y, x) and veg_type variable
-        # ds = xr.Dataset(
-        #     data_vars={
-        #         "veg_type": (
-        #             ["time", "y", "x"],
-        #             np.full((len(time_range), len(y), len(x)), np.nan),
-        #         ),
-        #         "maturity": (
-        #             ["time", "y", "x"],
-        #             np.full((len(time_range), len(y), len(x)), np.nan),
-        #         ),
-        #         "zone_v_condition_1": (
-        #             ["time", "y", "x"],
-        #             np.full((len(time_range), len(y), len(x)), np.nan),
-        #         ),
-        #         "zone_v_condition_2": (
-        #             ["time", "y", "x"],
-        #             np.full((len(time_range), len(y), len(x)), np.nan),
-        #         ),
-        #     },
-        #     coords={"time": time_range, "y": y, "x": x},
-        # )
-
         # Add metadata
         # ds["veg_type"].attrs["description"] = "Vegetation type classification"
         # ds["veg_type"].attrs["units"] = "Category"
@@ -908,26 +885,6 @@ class VegTransition:
 
             # Assign the data to the dataset for the specific time step
             ds[var_name].loc[{"time": timestep_str}] = data.astype(ds[var_name].dtype)
-
-            # # create var if not already existing, with full timeseries of nan
-            # if var_name not in ds:
-            #     ds[var_name] = (
-            #         ["time", "y", "x"],
-            #         np.full(
-            #             (len(ds.time), len(ds.y), len(ds.x)), np.nan
-            #         ),  # fills float
-            #     )
-
-            # # Explicitly convert condition arrays to bool and ensure NaNs are replaced
-            # if "condition" in var_name:
-            #     data = np.nan_to_num(data, nan=False).astype(
-            #         bool
-            #     )  # Replace NaNs with False
-
-            #     ds[var_name].loc[{"time": timestep_str}] = data.astype(bool)
-
-            # else:
-            #     ds[var_name].loc[{"time": timestep_str}] = data
 
         ds.close()
         ds.to_netcdf(self.netcdf_filepath, mode="a")

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -260,62 +260,57 @@ class VegTransition:
         self._logger.info("Masking veg type array to domain.")
         self.veg_type = np.where(self.hecras_domain, self.veg_type, np.nan)
 
-        # brainstorm for saving condition arrays
+        # note: arrays are named for their starting veg type
         self.zone_v = veg_logic.zone_v(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
         )
-        self.veg_type_update_1 = self.zone_v["veg_type"]
-
         self.zone_iv = veg_logic.zone_iv(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
         )
-
-        self.veg_type_update_2 = self.zone_iv["veg_type"]
-
-        self.veg_type_update_3 = veg_logic.zone_iii(
+        self.zone_iii = veg_logic.zone_iii(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
         )
-        self.veg_type_update_4 = veg_logic.zone_ii(
+        self.zone_ii = veg_logic.zone_ii(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
         )
-        self.veg_type_update_5 = veg_logic.fresh_shrub(
+        self.fresh_shrub = veg_logic.fresh_shrub(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
         )
-        self.veg_type_update_6 = veg_logic.fresh_marsh(
-            self.veg_type,
-            self.water_depth,
-            self.timestep_output_dir_figs,
-            self.salinity,
-        )
-        self.veg_type_update_7 = veg_logic.intermediate_marsh(
+        self.fresh_marsh = veg_logic.fresh_marsh(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
             self.salinity,
         )
-        self.veg_type_update_8 = veg_logic.brackish_marsh(
+        self.intermediate_marsh = veg_logic.intermediate_marsh(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
             self.salinity,
         )
-        self.veg_type_update_9 = veg_logic.saline_marsh(
+        self.brackish_marsh = veg_logic.brackish_marsh(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
             self.salinity,
         )
-        self.veg_type_update_10 = veg_logic.water(
+        self.saline_marsh = veg_logic.saline_marsh(
+            self.veg_type,
+            self.water_depth,
+            self.timestep_output_dir_figs,
+            self.salinity,
+        )
+        self.water = veg_logic.water(
             self.veg_type,
             self.water_depth,
             self.timestep_output_dir_figs,
@@ -328,16 +323,16 @@ class VegTransition:
         # outside of the HEC-RAS domain.
         stacked_veg = np.stack(
             (
-                self.veg_type_update_1,
-                self.veg_type_update_2,
-                self.veg_type_update_3,
-                self.veg_type_update_4,
-                self.veg_type_update_5,
-                self.veg_type_update_6,
-                self.veg_type_update_7,
-                self.veg_type_update_8,
-                self.veg_type_update_9,
-                self.veg_type_update_10,
+                self.zone_v["veg_type"],
+                self.zone_iv["veg_type"],
+                self.zone_iii["veg_type"],
+                self.zone_ii["veg_type"],
+                self.fresh_shrub["veg_type"],
+                self.fresh_marsh["veg_type"],
+                self.intermediate_marsh["veg_type"],
+                self.brackish_marsh["veg_type"],
+                self.saline_marsh["veg_type"],
+                self.water["veg_type"],
                 self.static_veg,
             )
         )
@@ -349,7 +344,7 @@ class VegTransition:
 
         # combine arrays while preserving NaN
         self._logger.info("Combining new vegetation types into full array.")
-        self.veg_type = np.full_like(self.veg_type_update_1, np.nan)
+        self.veg_type = np.full_like(self.zone_v["veg_type"], np.nan)
         for layer in stacked_veg:
             self.veg_type = np.where(np.isnan(self.veg_type), layer, self.veg_type)
 
@@ -856,39 +851,83 @@ class VegTransition:
             # qc vars below
             "zone_v_condition_1": self.zone_v["condition_1"],
             "zone_v_condition_2": self.zone_v["condition_2"],
+            #
             "zone_iv_condition_1": self.zone_iv["condition_1"],
             "zone_iv_condition_2": self.zone_iv["condition_2"],
             "zone_iv_condition_3": self.zone_iv["condition_3"],
-            # "alligator_si_3": self.alligator.si_3,
-            # "alligator_si_4": self.alligator.si_4,
-            # "alligator_si_5": self.alligator.si_5,
-            # #
-            # "bald_eagle_hsi": self.baldeagle.hsi,
-            # "bald_eagle_si_1": self.baldeagle.si_1,
-            # "bald_eagle_si_2": self.baldeagle.si_2,
-            # "bald_eagle_si_3": self.baldeagle.si_3,
-            # "bald_eagle_si_4": self.baldeagle.si_4,
-            # "bald_eagle_si_5": self.baldeagle.si_5,
-            # "bald_eagle_si_6": self.baldeagle.si_6,
-            # #
-            # "crawfish_hsi": self.crawfish.hsi,
-            # "crawfish_si_1": self.crawfish.si_1,
-            # "crawfish_si_2": self.crawfish.si_2,
-            # "crawfish_si_3": self.crawfish.si_3,
-            # "crawfish_si_4": self.crawfish.si_4,
-            # "black_bear_hsi": self.black_bear.hsi,
+            #
+            "zone_iii_condition_1": self.zone_iii["condition_1"],
+            "zone_iii_condition_2": self.zone_iii["condition_2"],
+            "zone_iii_condition_3": self.zone_iii["condition_3"],
+            #
+            "zone_ii_condition_1": self.zone_ii["condition_1"],
+            "zone_ii_condition_2": self.zone_ii["condition_2"],
+            "zone_ii_condition_3": self.zone_ii["condition_3"],
+            "zone_ii_condition_4": self.zone_ii["condition_4"],
+            #
+            "fresh_shrub_condition_1": self.fresh_shrub["condition_1"],
+            "fresh_shrub_condition_2": self.fresh_shrub["condition_2"],
+            "fresh_shrub_condition_3": self.fresh_shrub["condition_3"],
+            #
+            "fresh_marsh_condition_1": self.fresh_marsh["condition_1"],
+            "fresh_marsh_condition_2": self.fresh_marsh["condition_2"],
+            "fresh_marsh_condition_3": self.fresh_marsh["condition_3"],
+            "fresh_marsh_condition_4": self.fresh_marsh["condition_4"],
+            #
+            "intermediate_marsh_condition_1": self.intermediate_marsh["condition_1"],
+            "intermediate_marsh_condition_2": self.intermediate_marsh["condition_2"],
+            "intermediate_marsh_condition_3": self.intermediate_marsh["condition_3"],
+            #
+            "brackish_marsh_condition_1": self.brackish_marsh["condition_1"],
+            "brackish_marsh_condition_2": self.brackish_marsh["condition_2"],
+            "brackish_marsh_condition_3": self.brackish_marsh["condition_3"],
+            #
+            "saline_marsh_condition_1": self.saline_marsh["condition_1"],
+            "saline_marsh_condition_2": self.saline_marsh["condition_2"],
+            #
+            "water_condition_1_3_5_7": self.water["condition_1_3_5_7"],
+            "water_condition_2": self.water["condition_2"],
+            "water_condition_4": self.water["condition_4"],
+            "water_condition_6": self.water["condition_6"],
         }
 
         for var_name, data in veg_variables.items():
-            # create var if not already existing, with full timeseries of nan
+            # Check if the variable exists in the dataset, if not, initialize it
             if var_name not in ds:
+                shape = (len(ds.time), len(ds.y), len(ds.x))
+                default_value = np.nan if "condition" not in var_name else False
+                dtype = float if "condition" not in var_name else bool
                 ds[var_name] = (
                     ["time", "y", "x"],
-                    np.full((len(ds.time), len(ds.y), len(ds.x)), np.nan),
+                    np.full(shape, default_value, dtype=dtype),
                 )
 
-            # assign values for timestep
-            ds[var_name].loc[{"time": timestep_str}] = data
+            # Convert 'condition' variables to boolean, replacing NaN values with False
+            if "condition" in var_name:
+                data = np.nan_to_num(data, nan=False).astype(bool)
+
+            # Assign the data to the dataset for the specific time step
+            ds[var_name].loc[{"time": timestep_str}] = data.astype(ds[var_name].dtype)
+
+            # # create var if not already existing, with full timeseries of nan
+            # if var_name not in ds:
+            #     ds[var_name] = (
+            #         ["time", "y", "x"],
+            #         np.full(
+            #             (len(ds.time), len(ds.y), len(ds.x)), np.nan
+            #         ),  # fills float
+            #     )
+
+            # # Explicitly convert condition arrays to bool and ensure NaNs are replaced
+            # if "condition" in var_name:
+            #     data = np.nan_to_num(data, nan=False).astype(
+            #         bool
+            #     )  # Replace NaNs with False
+
+            #     ds[var_name].loc[{"time": timestep_str}] = data.astype(bool)
+
+            # else:
+            #     ds[var_name].loc[{"time": timestep_str}] = data
 
         ds.close()
         ds.to_netcdf(self.netcdf_filepath, mode="a")


### PR DESCRIPTION
Follow-on PR, finalizing the move to NetCDF.

1. NetCDF output for `VegTransition` now has a tuple to specify the data type alongside the array. The decreases output file size. The default for floats is now float32 instead of float64. These output arrays are now changed to represent JV's list of QC vars.
2. JV's QAQC arrays are now defined in `utils` and called by `VegTransition.create_qc_arrays()`
3. The filename convention method in `utils.generate_filename()` is less strict and will generate a filename with whatever args are provided, rather than demanding all args, as some args are not relevant internal use. Filenames are still built up piecemeal; this could be made more clear (back burner).
4. `veg_logic.py` - All of the veg type functions now return a dict as `dict[str, np.ndarray]`, where the first array in the dict is the expected `veg_type` output. The following are the boolean condition arrays. This change makes the condition arrays available as an output from the model. Access to these arrays has been updated throughout to reflect this change.
5. `crawfish.py` has been updated to handle NaNs in the input vars, solving  #36
6. In the `HSI` config, `veg_type_path`, i.e. the output from `VegTransition` is now an absolute path as it is a single NetCDF file rather than a dir. 

