### PR TITLE
dr-in-progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ ___
 Description: This folder contains code for processing inputs and executing the vegetation transition model, as well as the subsequent HSI model implementation. It handles input data preprocessing, vegetation type transitions based on environmental conditions (e.g., water depth, salinity), and generating outputs for analysis and visualization. The `VegTransition` model is designed to simulate vegetation dynamics over time and provide inputs for Habitat Suitability Index (HSI) models.
 
 #### Contents:
-- `veg_transition.py`: Core logic for vegetation transition modeling, implementing rules and conditions for vegetation type changes over time. The `VegTransition` class is initialized with a `config.yaml` which defines the model parameters. The `run()` method executes the model.
+- `veg_transition.py`: Framework for vegetation transition modeling, implementing rules and conditions for vegetation type changes over time. The `VegTransition` class is initialized with a `config.yaml` which defines the model parameters. The `run()` method executes the model.
+- `hsi.py`: Framework for running the HSI models over the domain. `HSI` is a child class of `VegTransition` and inherits much of it's functionality for updating state variables over time.
 - `veg_logic.py`: Detailed implementation of vegetation transition rules, handling specific conditions and constraints for various vegetation types.
 - `test.py`: Unit testing of vegetation zone logic.
 - `utils.py`: General utility functions for working with file paths, datasets, and common logic used throughout the model. Includes functions to generate the 25-year sequenves. Also includes runtime testing that occurs during execution.
@@ -33,13 +34,118 @@ ___
 - CSV files defining the ordering of analog years with the 25 year sequences.
 
 ___
-#### `VegProcessor/sequences`
+#### `VegProcessor/species_hsi`
 Description: this folder contains the individual species HSI logic.
 #### Contents:
 - `alligator.py`
 - `bald_eagle.py`
+- `bass.py`
+- `gizzardshad.py`
 
+___
+### Setup for Model Runs & Development
+
+#### **1. Clone the Repository**
+
+Ensure **Git** is installed, then open a terminal and run:
+
+```bash
+git clone https://github.com/LynkerIntel/cpra-hsi.git
+cd cpra-hsi
+```
+
+---
+
+#### **2. Create and Activate a Conda Environment**
+
+An environment file, `environment_multiplatform.yml`, is provided. Create the Conda environment using:
+
+```bash
+conda env create -f environment/environment_multiplatform.yml
+```
+
+Activate the environment:
+
+```bash
+conda activate cpra_env
+```
+
+This installs the necessary dependencies, including:
+
+- **GIS & Spatial Analysis**: `gdal`, `shapely`, `geojson`, `geopandas`, `rioxarray`, `cartopy`, `geocube`
+- **Data Processing & Visualization**: `xarray`, `numpy`, `pandas`, `matplotlib`, `plotly`, `dash`, `dash-bootstrap-components`
+- **Cloud & Utility Tools**: `boto3`, `requests`, `python-dotenv`
+- **Python & Development Tools**: `mypy`, `isodate`, `future`, `pyyaml`, `ipykernel`, `nbformat`, `appdirs`
+
+The environment is currently not defined with pinned versions, in order to maximize capatibility. Conda will install the latest version of packages that does not create conflicts. This will change to pinned versions.
+
+
+---
+
+#### **3. Configure the Model**
+
+In order to run scenarios (i.e. base or sea level rise), 25-year sequences must be generated from the analog years, using  `utils.generate_combined_sequence()`. Be aware that these sequences take up substantial space (~ 20 gig). Next, edit the configuration files in `./configs/`, pointing each path to a local file.
+
+- `VegProcessor/veg_config_**`: Specifies vegetation transition model settings, raster data paths, and output locations.
+- `VegProcessor/hsi_config_**`: Defines parameters for running the Habitat Suitability Index model.
+
+##### These steps are demonstrated in `./VegProcessor/run.ipynb`
+---
+To execute the vegetation transition model:
+
+```python
+from VegProcessor.veg_transition import VegTransition
+
+# Initialize the model with a config file
+veg_model = VegTransition(config_file="./configs/veg_config.yaml")
+
+# Run the model
+veg_model.run()
+```
+##### These steps are demonstrated in `./VegProcessor/run.ipynb`
+---
+Keep in mind that the HSI models depend on the `VegTransition` output, and must always be executed second. To run the **Habitat Suitability Index (HSI)** model:
+
+```python
+from VegProcessor.hsi import HSI
+
+# Initialize the HSI model
+hsi_model = HSI(config_file="./configs/hsi_config.yaml")
+
+# Run the model
+hsi_model.run()
+```
+##### These steps are demonstrated in `./VegProcessor/run.ipynb`
+---
+
+## **7. Debugging & Logs**
+
+- Logs are stored in `output/run-metadata/simulation.log`
+- Check logs if the model fails to run or if there are errors in output files.
+- If running `VegTransition` or `HSI` in a notebook, the class instance (i.e. `hsi_model` as defind above) holds all of the interediate and QA/QC arrays as attributes. For example: `hsi_model.alligator.si_1` is the location of suitability index #1 array for alligator. This array be be visualized by:
+
+    ```python
+    import matplotlib.pyplot as plt
+
+    plt.matshow(hsi_model.alligator.si_1)
+    plt.colorbar()
+    ```
+
+---
+
+## **8. Cleaning Up**
+
+To deactivate the Conda environment:
+
+```bash
+conda deactivate
+```
+
+To remove the environment completely:
+
+```bash
+conda remove --name cpra_env --all -y
+```
 ___
 #### VegTransition
 ![alt text](./fig.png)
-

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ hsi_model.run()
     ```python
     import matplotlib.pyplot as plt
 
-    plt.matshow(hsi_model.alligator.si_1)
+    plt.matshow(hsi_model.alligator.si_1) # np.ndarray
     plt.colorbar()
     ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Description: this folder contains the individual species HSI logic.
 - `bald_eagle.py`
 - `bass.py`
 - `gizzardshad.py`
+- `crawfish.py`
 
 ___
 ### Setup for Model Runs & Development

--- a/VegProcessor/configs/hsi_config_testing.yaml
+++ b/VegProcessor/configs/hsi_config_testing.yaml
@@ -4,6 +4,7 @@ raster_data:
   dem_path: "/Users/dillonragar/data/cpra/AMP_NGOM2_DEM_60m_Bilinear_Resample.tif" # str
   #wse_directory_path: "/Users/dillonragar/data/tmp/cpra/AMP_SimulationResults" # must be unzipped
   wse_directory_path: "/Users/dillonragar/data/tmp/cpra/base-sequence-wet"
+  wse_domain_raster: "/Users/dillonragar/data/cpra/HECRAS_domain_60m.tif"
   veg_base_raster: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif" #str
   veg_keys: "/Users/dillonragar/data/cpra/AMP_10km_LULC_60m_Nearest_Resample/AMP_10kmBuffer_LULC_60m_Nearest_Resample.tif.vat.dbf"
   wpu_path: /Users/dillonragar/Library/CloudStorage/OneDrive-LynkerTechnologies/2024 CPRA Atchafalaya DSS/data/WPU_id_60m.tif # 60m domain with pixels labeled by WPU

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -21,28 +21,6 @@ import veg_transition as vt
 from species_hsi import alligator, crawfish, baldeagle
 
 
-# this is a c/p from veg class, not sure why I need it again here.
-class _TimestepFilter(logging.Filter):
-    """A roundabout way to inject the current timestep into log records.
-    Should & could be simplified.
-
-    N/A if log messages occurs while self.current_timestep is not set.
-    """
-
-    def __init__(self, veg_transition_instance):
-        super().__init__()
-        self.veg_transition_instance = veg_transition_instance
-
-    def filter(self, record):
-        # Dynamically add the current timestep to log records
-        record.timestep = (
-            self.veg_transition_instance.current_timestep.strftime("%Y-%m-%d")
-            if self.veg_transition_instance.current_timestep
-            else "N/A"
-        )
-        return True
-
-
 class HSI(vt.VegTransition):
     """HSI model framework."""
 

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -62,9 +62,6 @@ class HSI(vt.VegTransition):
 
         # metadata
         self.metadata = self.config["metadata"]
-        # self.scenario_type = self.config["metadata"].get(
-        #     "scenario", ""
-        # )  # empty str if missing
 
         # output
         self.output_base_dir = self.config["output"].get("output_base")
@@ -166,12 +163,12 @@ class HSI(vt.VegTransition):
         file_params = {
             "model": self.metadata.get("model"),
             "scenario": self.metadata.get("scenario"),
-            "group": self.metadata.get("group"),  # not sure if this is correct,
+            "group": self.metadata.get("group"),
             "wpu": "AB",
             "io_type": "O",
             "time_freq": "ANN",  # for annual output
             "year_range": f"01_{str(sim_length + 1).zfill(2)}",
-            # "parameter": "NA",  # ?
+            # "parameter": "NA",
         }
 
         self._create_output_file(file_params)
@@ -232,7 +229,7 @@ class HSI(vt.VegTransition):
         date: pd.DatetimeTZDtype
             current datetime as pandas dt type
         """
-        self.current_timestep = date  # Set the current timestep
+        self.current_timestep = date
         wy = date.year
 
         self._logger.info("starting timestep: %s", date)
@@ -742,7 +739,6 @@ class HSI(vt.VegTransition):
                 )
 
             # assign values for timestep
-            # not dtype rules needed here as 480m cell is light
             ds[var_name].loc[{"time": timestep_str}] = data
 
         ds.close()

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -93,6 +93,7 @@ class HSI(vt.VegTransition):
 
         # Generate static variables
         self.dem = self._load_dem()
+        self.dem_480 = self._load_dem(cell=True)
         self.veg_keys = self._load_veg_keys()
         self.edge = self._calculate_edge()
         self.initial_veg_type = self._load_veg_initial_raster(
@@ -509,7 +510,6 @@ class HSI(vt.VegTransition):
         filtered_ds = ds.sel(time=self.wse["time"].dt.month.isin(months))
         ds = filtered_ds.mean(dim="time", skipna=True)["WSE_MEAN"]
 
-        # upscale to 480m from 60m
         da_coarse = ds.coarsen(y=8, x=8, boundary="pad").mean()
         return da_coarse.to_numpy()
 

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -209,6 +209,11 @@ class HSI(vt.VegTransition):
 
         TODO: for memory efficiency, 60m arrays should be garbage collected after creation of
         480m HSI input arrays.
+
+        Params
+        -------
+        date: pd.DatetimeTZDtype
+            current datetime as pandas dt type
         """
         self.current_timestep = date  # Set the current timestep
         wy = date.year
@@ -251,7 +256,6 @@ class HSI(vt.VegTransition):
     def run(self):
         """
         Run the vegetation transition model, with parameters defined in the configuration file.
-
         Start and end parameters are year, and handled as ints. No other frequency currently possible.
         """
         # run model forwards
@@ -352,12 +356,8 @@ class HSI(vt.VegTransition):
         self.pct_saline_marsh = ds["pct_cover_23"].to_numpy()
         self.pct_open_water = ds["pct_cover_26"].to_numpy()
 
-        # Zone V, IV, III
-        # self.pct_swamp_bottom_hardwood = ds_blh.to_numpy()
-
         # Zone V, IV, III, (BLH's) II (swamp)
         self.pct_swamp_bottom_hardwood = ds_swamp_blh.to_numpy()
-        # self._logger.debug("Completed _calculate_pct_cover")
 
     def _calculate_pct_cover_static(self):
         """Get percent coverage for each 480m cell, based on 60m veg type pixels.

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -499,7 +499,7 @@ class HSI(vt.VegTransition):
             A water depth data, averaged over a list of months (if provided)
             and then downscaled to 480m.
         """
-        ds = super()._get_depth()
+        ds = super()._get_depth()  # VegTransition._get_depth()
 
         if not months:
             months = [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]

--- a/VegProcessor/plotting.py
+++ b/VegProcessor/plotting.py
@@ -11,7 +11,6 @@ import gc
 from typing import Optional
 
 
-matplotlib.use("Agg")  # may be needed to prevent mpl memory leak
 logger = logging.getLogger("VegTransition")
 
 

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -66,6 +66,8 @@ class AlligatorHSI:
         # Set up the logger
         self._setup_logger()
 
+        self.template = self._create_template_array()
+
         # Calculate individual suitability indices
         self.si_1 = self.calculate_si_1()
         self.si_2 = self.calculate_si_2()
@@ -75,6 +77,13 @@ class AlligatorHSI:
 
         # Calculate overall suitability score with quality control
         self.hsi = self.calculate_overall_suitability()
+
+    def _create_template_array(self) -> np.ndarray:
+        """Create an array from a template all valid pixels are 999.0, and
+        NaN from the input are persisted.
+        """
+        arr = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+        return arr
 
     def _setup_logger(self):
         """Set up the logger for the class."""
@@ -99,7 +108,7 @@ class AlligatorHSI:
     def calculate_si_1(self) -> np.ndarray:
         """Percent of cell that is open water."""
         self._logger.info("Running SI 1")
-        si_1 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+        si_1 = self.template.copy()
 
         if self.v1_pct_open_water is None:
             self._logger.info("Pct open water data not provided. Setting index to 1.")
@@ -127,8 +136,7 @@ class AlligatorHSI:
     def calculate_si_2(self) -> np.ndarray:
         """Mean annual water depth relative to the marsh surface."""
         self._logger.info("Running SI 2")
-        # initialize with NaN from depth array, else 999
-        si_2 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+        si_2 = self.template.copy()
 
         if self.v2_water_depth_annual_mean is None:
             self._logger.info(
@@ -166,7 +174,7 @@ class AlligatorHSI:
         """Proportion of cell covered by habitat types."""
         self._logger.info("Running SI 3")
         # initialize with NaN from depth array, else 999
-        si_3 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+        si_3 = self.template.copy()
 
         si_3 = (
             (0.551 * self.v3a_pct_swamp_bottom_hardwood)
@@ -183,8 +191,7 @@ class AlligatorHSI:
     def calculate_si_4(self) -> np.ndarray:
         """Edge."""
         self._logger.info("Running SI 4")
-        # initialize with NaN from depth array, else 999
-        si_4 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+        si_4 = self.template.copy()
 
         if self.v4_edge is None:
             self._logger.info("Edge data not provided. Setting index to 1.")
@@ -207,8 +214,7 @@ class AlligatorHSI:
     def calculate_si_5(self) -> np.ndarray:
         """Mean annual salinity."""
         self._logger.info("Running SI 5")
-        # initialize with NaN from depth array, else 999
-        si_5 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+        si_5 = self.template.copy()
 
         if self.v5_mean_annual_salinity is None:
             self._logger.info(

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -28,6 +28,8 @@ class AlligatorHSI:
     v4_edge: np.ndarray = None
     v5_mean_annual_salinity: np.ndarray = None
 
+    dem: np.ndarray = None
+
     # Suitability indices (calculated)
     si_1: np.ndarray = field(init=False)
     si_2: np.ndarray = field(init=False)
@@ -59,6 +61,7 @@ class AlligatorHSI:
             v3d_pct_brackish_marsh=safe_divide(hsi_instance.pct_brackish_marsh),
             v4_edge=hsi_instance.edge,
             v5_mean_annual_salinity=hsi_instance.mean_annual_salinity,
+            dem=hsi_instance.dem_480,
         )
 
     def __post_init__(self):
@@ -270,4 +273,8 @@ class AlligatorHSI:
                 num_invalid_hsi,
             )
 
-        return hsi
+        # subset final HSI array to vegetation domain (not hydrologic domain)
+        # Masking: Set values in `mask` to NaN wherever `data` is NaN
+        masked_hsi = np.where(np.isnan(self.dem), np.nan, hsi)
+
+        return masked_hsi

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -167,16 +167,6 @@ class AlligatorHSI:
         """Proportion of cell covered by habitat types."""
         self._logger.info("Running SI 3")
 
-        for array in [
-            self.v3a_pct_swamp_bottom_hardwood,
-            self.v3b_pct_fresh_marsh,
-            self.v3c_pct_intermediate_marsh,
-            self.v3d_pct_brackish_marsh,
-        ]:
-            if array is None:
-                self._logger.info("%s not provided. Setting index to 1.", array)
-                array = np.ones(self._shape)
-
         si_3 = (
             (0.551 * self.v3a_pct_swamp_bottom_hardwood)
             + (0.713 * self.v3b_pct_fresh_marsh)

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -42,9 +42,9 @@ class AlligatorHSI:
     def from_hsi(cls, hsi_instance):
         """Create AlligatorHSI instance from an HSI instance."""
 
-        def safe_divide(value, divisor=100):
+        def safe_divide(array: np.ndarray, divisor: int = 100) -> np.ndarray:
             """Helper function to safely divide a value if it's not None."""
-            return value / divisor if value is not None else None
+            return array / divisor if array is not None else None
 
         return cls(
             v1_pct_open_water=safe_divide(hsi_instance.pct_open_water),

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -98,15 +98,14 @@ class AlligatorHSI:
 
     def calculate_si_1(self) -> np.ndarray:
         """Percent of cell that is open water."""
+        self._logger.info("Running SI 1")
+        si_1 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+
         if self.v1_pct_open_water is None:
             self._logger.info("Pct open water data not provided. Setting index to 1.")
-            si_1 = np.ones(self._shape)
+            si_1[~np.isnan(si_1)] = 1
 
         else:
-            self._logger.info("Running SI 1")
-            # Create an array to store the results
-            si_1 = np.full(self._shape, 999.0)
-
             # condition 1
             mask_1 = self.v1_pct_open_water < 0.2
             si_1[mask_1] = (4.5 * self.v1_pct_open_water[mask_1]) + 0.1
@@ -127,18 +126,18 @@ class AlligatorHSI:
 
     def calculate_si_2(self) -> np.ndarray:
         """Mean annual water depth relative to the marsh surface."""
+        self._logger.info("Running SI 2")
+        # initialize with NaN from depth array, else 999
+        si_2 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+
         if self.v2_water_depth_annual_mean is None:
             self._logger.info(
                 "avg annual water depth relative to marsh surface data not provided. Setting index to 1."
             )
-            si_2 = np.ones(self._shape)
+            # Replace all non-NaN values with 1
+            si_2[~np.isnan(si_2)] = 1
 
         else:
-            self._logger.info("Running SI 2")
-            # Not using 999 as init value, because depth has
-            # many NaN pixels, instead these become 0
-            si_2 = np.full(self._shape, 0.0)  # must be float value!
-
             # condition 1 (OR)
             mask_1 = (self.v2_water_depth_annual_mean <= -0.55) | (
                 self.v2_water_depth_annual_mean >= 0.25
@@ -166,6 +165,8 @@ class AlligatorHSI:
     def calculate_si_3(self) -> np.ndarray:
         """Proportion of cell covered by habitat types."""
         self._logger.info("Running SI 3")
+        # initialize with NaN from depth array, else 999
+        si_3 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
 
         si_3 = (
             (0.551 * self.v3a_pct_swamp_bottom_hardwood)
@@ -174,18 +175,23 @@ class AlligatorHSI:
             + (0.408 * self.v3d_pct_brackish_marsh)
         )
 
-        # TODO: error handling here? (for case where no blank arr is initialized)
+        if np.any(np.isclose(si_3, 999.0, atol=1e-5)):
+            raise ValueError("Unhandled condition in SI logic!")
+
         return si_3
 
     def calculate_si_4(self) -> np.ndarray:
         """Edge."""
+        self._logger.info("Running SI 4")
+        # initialize with NaN from depth array, else 999
+        si_4 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+
         if self.v4_edge is None:
             self._logger.info("Edge data not provided. Setting index to 1.")
-            si_4 = np.ones(self._shape)
+            # Replace all non-NaN values with 1
+            si_4[~np.isnan(si_4)] = 1
 
         else:
-            self._logger.info("Running SI 4")
-            si_4 = np.full(self._shape, 999.0)
             mask_1 = (self.v4_edge >= 0) & (self.v4_edge <= 22)
             si_4[mask_1] = 0.05 + (0.95 * (self.v4_edge[mask_1] / 22))
 
@@ -200,15 +206,18 @@ class AlligatorHSI:
 
     def calculate_si_5(self) -> np.ndarray:
         """Mean annual salinity."""
+        self._logger.info("Running SI 5")
+        # initialize with NaN from depth array, else 999
+        si_5 = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
+
         if self.v5_mean_annual_salinity is None:
             self._logger.info(
                 "mean annual salinity data not provided. Setting index to 1."
             )
-            si_5 = np.ones(self._shape)
+            # Replace all non-NaN values with 1
+            si_5[~np.isnan(si_5)] = 1
 
         else:
-            self._logger.info("Running SI 5")
-            si_5 = np.full(self._shape, 999.0)  # must be float
             mask_1 = (self.v5_mean_annual_salinity >= 0) & (
                 self.v5_mean_annual_salinity <= 10
             )

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -41,13 +41,20 @@ class AlligatorHSI:
     @classmethod
     def from_hsi(cls, hsi_instance):
         """Create AlligatorHSI instance from an HSI instance."""
+
+        def safe_divide(value, divisor=100):
+            """Helper function to safely divide a value if it's not None."""
+            return value / divisor if value is not None else None
+
         return cls(
-            v1_pct_open_water=hsi_instance.pct_open_water / 100,
+            v1_pct_open_water=safe_divide(hsi_instance.pct_open_water),
             v2_water_depth_annual_mean=hsi_instance.water_depth_annual_mean,
-            v3a_pct_swamp_bottom_hardwood=hsi_instance.pct_swamp_bottom_hardwood / 100,
-            v3b_pct_fresh_marsh=hsi_instance.pct_fresh_marsh / 100,
-            v3c_pct_intermediate_marsh=hsi_instance.pct_intermediate_marsh / 100,
-            v3d_pct_brackish_marsh=hsi_instance.pct_brackish_marsh / 100,
+            v3a_pct_swamp_bottom_hardwood=safe_divide(
+                hsi_instance.pct_swamp_bottom_hardwood
+            ),
+            v3b_pct_fresh_marsh=safe_divide(hsi_instance.pct_fresh_marsh),
+            v3c_pct_intermediate_marsh=safe_divide(hsi_instance.pct_intermediate_marsh),
+            v3d_pct_brackish_marsh=safe_divide(hsi_instance.pct_brackish_marsh),
             v4_edge=hsi_instance.edge,
             v5_mean_annual_salinity=hsi_instance.mean_annual_salinity,
         )

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -57,9 +57,6 @@ class AlligatorHSI:
         # Set up the logger
         self._setup_logger()
 
-        # Determine the shape of the arrays
-        self._shape = self._determine_shape()
-
         # Calculate individual suitability indices
         self.si_1 = self.calculate_si_1()
         self.si_2 = self.calculate_si_2()
@@ -89,12 +86,6 @@ class AlligatorHSI:
 
             # Add the handler to the logger
             self._logger.addHandler(ch)
-
-    def _determine_shape(self) -> tuple:
-        """Determine the shape of the environmental variable arrays."""
-        # Iterate over instance attributes and return the shape of the first non None numpy array
-        return self.v1_pct_open_water.shape
-        # raise ValueError("At least one S.I. raster input must be provided.")
 
     def calculate_si_1(self) -> np.ndarray:
         """Percent of cell that is open water."""

--- a/VegProcessor/species_hsi/alligator.py
+++ b/VegProcessor/species_hsi/alligator.py
@@ -43,7 +43,9 @@ class AlligatorHSI:
         """Create AlligatorHSI instance from an HSI instance."""
 
         def safe_divide(array: np.ndarray, divisor: int = 100) -> np.ndarray:
-            """Helper function to safely divide a value if it's not None."""
+            """Helper function to divide arrays when decimal values are required
+            by the SI logic. In the case of None (no array) it is preserved and
+            passed to SI methods."""
             return array / divisor if array is not None else None
 
         return cls(

--- a/VegProcessor/species_hsi/baldeagle.py
+++ b/VegProcessor/species_hsi/baldeagle.py
@@ -24,11 +24,7 @@ class BaldEagleHSI:
     v5_pct_cell_intermediate_marsh: np.ndarray = None
     v6_pct_cell_open_water: np.ndarray = None
 
-    # Species-specific parameters (example values)
-    # for cases where static values are used
-
-    # optimal_temperature: float = 20.0  # EXAMPLE
-    # temperature_tolerance: float = 10.0  # EXAMPLE
+    dem: np.ndarray = None
 
     # Suitability indices (calculated)
     si_1: np.ndarray = field(init=False)
@@ -70,6 +66,7 @@ class BaldEagleHSI:
             v6_pct_cell_open_water=safe_divide(
                 hsi_instance.pct_open_water,
             ),
+            dem=hsi_instance.dem_480,
         )
 
     def __post_init__(self):
@@ -120,18 +117,6 @@ class BaldEagleHSI:
 
             # Add the handler to the logger
             self._logger.addHandler(ch)
-
-    # def _determine_shape(self) -> tuple:
-    #     """Determine the shape of the environmental variable arrays."""
-    #     # Iterate over instance attributes and return the shape of the first non None numpy array
-    #     for name, value in vars(self).items():
-    #         if value is not None and isinstance(value, np.ndarray):
-    #             self._logger.info(
-    #                 "Using attribute %s as shape for output: %s", name, value.shape
-    #             )
-    #             return value.shape
-
-    #     raise ValueError("At least one S.I. raster input must be provided.")
 
     def calculate_si_1(self) -> np.ndarray:
         """Percent of cell that is developed land or upland."""
@@ -336,4 +321,8 @@ class BaldEagleHSI:
             # Clip the combined_score to ensure it's between 0 and 1
             # hsi = np.clip(hsi, 0, 1)
 
-        return hsi
+        # subset final HSI array to vegetation domain (not hydrologic domain)
+        # Masking: Set values in `mask` to NaN wherever `data` is NaN
+        masked_hsi = np.where(np.isnan(self.dem), np.nan, hsi)
+
+        return masked_hsi

--- a/VegProcessor/species_hsi/bass.py
+++ b/VegProcessor/species_hsi/bass.py
@@ -33,7 +33,7 @@ class BassHSI:
         return cls(
             v1a_mean_annual_salinity=hsi_instance.mean_annual_salinity,
             v1b_mean_annual_temperature=hsi_instance.mean_annual_temperature,
-            v2_pct_emergent_vegetation=hsi_instance.pct_vegetated
+            v2_pct_emergent_vegetation=hsi_instance.pct_vegetated,
         )
 
     def __post_init__(self):
@@ -71,6 +71,13 @@ class BassHSI:
             # Add the handler to the logger
             self._logger.addHandler(ch)
 
+    def _create_template_array(self) -> np.ndarray:
+        """Create an array from a template all valid pixels are 999.0, and
+        NaN from the input are persisted.
+        """
+        arr = np.full(self.v2_pct_emergent_vegetation.shape, 999.0)
+        return arr
+
     def _determine_shape(self) -> tuple:
         """Determine the shape of the environmental variable arrays."""
         # Iterate over instance attributes and return the shape of the first non None numpy array
@@ -84,7 +91,9 @@ class BassHSI:
     def calculate_si_1(self) -> np.ndarray:
         """Mean salinity and water temperature from the entire year."""
         if self.v1a_mean_annual_salinity is None:
-            self._logger.info("Mean annual salinity data not provided. Setting index to 1.")
+            self._logger.info(
+                "Mean annual salinity data not provided. Setting index to 1."
+            )
             si_1 = np.ones(self._shape)
 
         else:
@@ -92,30 +101,49 @@ class BassHSI:
             if self.v1b_mean_annual_temperature is None:
                 # self._logger.info("Mean annual temperature data not provided. Setting index to 1.")
                 # si_1 = np.ones(self._shape)
-                self._logger.info("Mean annual temperature data not provided. Using ideal conditions of 18 degrees C.")
+                self._logger.info(
+                    "Mean annual temperature data not provided. Using ideal conditions of 18 degrees C."
+                )
                 self.v1b_mean_annual_temperature = np.full(self._shape, 18)
-            
+
             # SI Logic
             self._logger.info("Running SI 1")
             # Create an array to store the results
             si_1 = np.full(self._shape, 999.0)
-            
+
             S_si = (self.v1a_mean_annual_salinity - 0.84) / 1.84
             T_si = (self.v1b_mean_annual_temperature - 22.68) / 4.64
-            S_si_2 = ((self.v1a_mean_annual_salinity * self.v1a_mean_annual_salinity) - 4.08) / 24.91
-            T_si_2 = ((self.v1b_mean_annual_temperature * self.v1b_mean_annual_temperature) - 535.99) / 206.16
+            S_si_2 = (
+                (self.v1a_mean_annual_salinity * self.v1a_mean_annual_salinity) - 4.08
+            ) / 24.91
+            T_si_2 = (
+                (self.v1b_mean_annual_temperature * self.v1b_mean_annual_temperature)
+                - 535.99
+            ) / 206.16
 
-            si_1 = np.exp(2.50 - (0.25 * S_si) + (0.30 * T_si) + (0.04 * S_si_2) - (0.33 * T_si_2) - (0.05 * (S_si * T_si))) / 14.3
+            si_1 = (
+                np.exp(
+                    2.50
+                    - (0.25 * S_si)
+                    + (0.30 * T_si)
+                    + (0.04 * S_si_2)
+                    - (0.33 * T_si_2)
+                    - (0.05 * (S_si * T_si))
+                )
+                / 14.3
+            )
 
             if np.any(np.isclose(si_1, 999.0, atol=1e-5)):
                 raise ValueError("Unhandled condition in SI logic!")
-        
+
         return si_1
 
     def calculate_si_2(self) -> np.ndarray:
         """Percent of cell that is covered by emergent vegetation."""
         if self.v2_pct_emergent_vegetation is None:
-            self._logger.info("Pct emergent vegetation data not provided. Setting index to 1.")
+            self._logger.info(
+                "Pct emergent vegetation data not provided. Setting index to 1."
+            )
             si_2 = np.ones(self._shape)
 
         else:
@@ -129,19 +157,27 @@ class BassHSI:
             si_2[mask_1] = 0.01
 
             # condition 2
-            mask_2 = (self.v2_pct_emergent_vegetation >= 20) & (self.v2_pct_emergent_vegetation < 30)
+            mask_2 = (self.v2_pct_emergent_vegetation >= 20) & (
+                self.v2_pct_emergent_vegetation < 30
+            )
             si_2[mask_2] = (0.099 * self.v2_pct_emergent_vegetation[mask_2]) - 1.997
 
             # condition 3
-            mask_3 = (self.v2_pct_emergent_vegetation >= 30) & (self.v2_pct_emergent_vegetation < 50)
+            mask_3 = (self.v2_pct_emergent_vegetation >= 30) & (
+                self.v2_pct_emergent_vegetation < 50
+            )
             si_2[mask_3] = 1.0
 
             # condition 4
-            mask_4 = (self.v2_pct_emergent_vegetation >= 50) & (self.v2_pct_emergent_vegetation < 85)
+            mask_4 = (self.v2_pct_emergent_vegetation >= 50) & (
+                self.v2_pct_emergent_vegetation < 85
+            )
             si_2[mask_4] = (-0.0283 * self.v2_pct_emergent_vegetation[mask_4]) + 2.414
 
             # condition 5
-            mask_5 = (self.v2_pct_emergent_vegetation >= 85) & (self.v2_pct_emergent_vegetation < 100)
+            mask_5 = (self.v2_pct_emergent_vegetation >= 85) & (
+                self.v2_pct_emergent_vegetation < 100
+            )
             si_2[mask_5] = 0.01
 
             # condition 6
@@ -151,7 +187,6 @@ class BassHSI:
             # Check for unhandled condition with tolerance
             if np.any(np.isclose(si_2, 999.0, atol=1e-5)):
                 raise ValueError("Unhandled condition in SI logic!")
-
 
         return si_2
 

--- a/VegProcessor/species_hsi/bass.py
+++ b/VegProcessor/species_hsi/bass.py
@@ -20,6 +20,8 @@ class BassHSI:
     v1b_mean_annual_temperature: np.ndarray = None
     v2_pct_emergent_vegetation: np.ndarray = None
 
+    dem: np.ndarray = None
+
     # Suitability indices (calculated)
     si_1: np.ndarray = field(init=False)
     si_2: np.ndarray = field(init=False)
@@ -34,6 +36,7 @@ class BassHSI:
             v1a_mean_annual_salinity=hsi_instance.mean_annual_salinity,
             v1b_mean_annual_temperature=hsi_instance.mean_annual_temperature,
             v2_pct_emergent_vegetation=hsi_instance.pct_vegetated,
+            dem=hsi_instance.dem_480,
         )
 
     def __post_init__(self):
@@ -218,4 +221,8 @@ class BassHSI:
                 num_invalid_hsi,
             )
 
-        return hsi
+        # subset final HSI array to vegetation domain (not hydrologic domain)
+        # Masking: Set values in `mask` to NaN wherever `data` is NaN
+        masked_hsi = np.where(np.isnan(self.dem), np.nan, hsi)
+
+        return masked_hsi

--- a/VegProcessor/species_hsi/crawfish.py
+++ b/VegProcessor/species_hsi/crawfish.py
@@ -28,6 +28,8 @@ class CrawfishHSI:
     v3g_pct_cell_bare_ground: np.ndarray = None
     v4_mean_water_depth_sept_dec: np.ndarray = None
 
+    dem: np.ndarray = None
+
     # Suitability indices (calculated)
     si_1: np.ndarray = field(init=False)
     si_2: np.ndarray = field(init=False)
@@ -62,6 +64,7 @@ class CrawfishHSI:
             v3f_pct_cell_saline_marsh=safe_divide(hsi_instance.pct_saline_marsh),
             v3g_pct_cell_bare_ground=safe_divide(hsi_instance.pct_bare_ground),
             v4_mean_water_depth_sept_dec=hsi_instance.water_depth_monthly_mean_sept_dec,
+            dem=hsi_instance.dem_480,
         )
 
     def __post_init__(self):
@@ -268,4 +271,8 @@ class CrawfishHSI:
                 num_invalid,
             )
 
-        return hsi
+        # subset final HSI array to vegetation domain (not hydrologic domain)
+        # Masking: Set values in `mask` to NaN wherever `data` is NaN
+        masked_hsi = np.where(np.isnan(self.dem), np.nan, hsi)
+
+        return masked_hsi

--- a/VegProcessor/species_hsi/crawfish.py
+++ b/VegProcessor/species_hsi/crawfish.py
@@ -28,12 +28,6 @@ class CrawfishHSI:
     v3g_pct_cell_bare_ground: np.ndarray = None
     v4_mean_water_depth_sept_dec: np.ndarray = None
 
-    # Species-specific parameters (example values)
-    # for cases where static values are used
-
-    # optimal_temperature: float = 20.0  # EXAMPLE
-    # temperature_tolerance: float = 10.0  # EXAMPLE
-
     # Suitability indices (calculated)
     si_1: np.ndarray = field(init=False)
     si_2: np.ndarray = field(init=False)
@@ -186,8 +180,8 @@ class CrawfishHSI:
             )
             si_2[mask_4] = 1.5 - (0.00457 * self.v2_mean_water_depth_jan_aug[mask_4])
 
-            # if np.any(np.isclose(si_2, 999.0, atol=1e-5)):
-            #     raise ValueError("Unhandled condition in SI logic!")
+            if np.any(np.isclose(si_2, 999.0, atol=1e-5)):
+                raise ValueError("Unhandled condition in SI logic!")
 
         return si_2
 
@@ -237,8 +231,8 @@ class CrawfishHSI:
             mask_3 = self.v4_mean_water_depth_sept_dec > 0.15
             si_4[mask_3] = 0.0
 
-            # if np.any(np.isclose(si_4, 999.0, atol=1e-5)):
-            #     raise ValueError("Unhandled condition in SI logic!")
+            if np.any(np.isclose(si_4, 999.0, atol=1e-5)):
+                raise ValueError("Unhandled condition in SI logic!")
 
         return si_4
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -16,16 +16,15 @@ class GizzardShadHSI:
 
     # gridded data as numpy arrays or None
     # init with None to be distinct from np.nan
-    v1_tds_summer_growing_season: np.ndarray = None #ideal
-    v2_avg_num_frost_free_days_growing_season: np.ndarray = None #ideal
-    v3_mean_weekly_summer_temp: np.ndarray = None #ideal
-    v4_max_do_summer: np.ndarray = None #ideal
-    v5_water_lvl_spawning_season: np.ndarray = None #ideal
-    v6_mean_weekly_temp_reservoir_spawning_season: np.ndarray = None #ideal
-    #v7_pct_vegetated_and_2m_depth_spawning_season : np.ndarray = None #use curve A
+    v1_tds_summer_growing_season: np.ndarray = None  # ideal
+    v2_avg_num_frost_free_days_growing_season: np.ndarray = None  # ideal
+    v3_mean_weekly_summer_temp: np.ndarray = None  # ideal
+    v4_max_do_summer: np.ndarray = None  # ideal
+    v5_water_lvl_spawning_season: np.ndarray = None  # ideal
+    v6_mean_weekly_temp_reservoir_spawning_season: np.ndarray = None  # ideal
+    # v7_pct_vegetated_and_2m_depth_spawning_season : np.ndarray = None #use curve A
     v7a_pct_vegetated: np.ndarray = None
     v7b_water_depth_spawning_season: np.ndarray = None
-
 
     # Suitability indices (calculated)
     si_1: np.ndarray = field(init=False)
@@ -109,13 +108,15 @@ class GizzardShadHSI:
         """LOG10 TOTAL DISSOLVED SOLIDS (PPM) DURING SUMMER GROWING SEASON"""
         # Set to ideal – there is no food limitation
         if self.v1_tds_summer_growing_season is None:
-            #self._logger.info("TDS during summer growing season data not provided. Setting index to 1.")
-            self._logger.info("TDS during summer growing season data assumes ideal conditions. Setting index to 1.")
+            # self._logger.info("TDS during summer growing season data not provided. Setting index to 1.")
+            self._logger.info(
+                "TDS during summer growing season data assumes ideal conditions. Setting index to 1."
+            )
             si_1 = np.ones(self._shape)
 
         # TODO: This will ALWAYS be set to ideal per hsi specs
         # consider include a diff if/else statement to handle ALWAYS IDEAL cases
-        #else:
+        # else:
         #    self._logger.info("Running SI 1")
         #    si_1 = np.full(self._shape, 999.0)
         return si_1
@@ -134,7 +135,7 @@ class GizzardShadHSI:
 
         # TODO: This will ALWAYS be set to ideal per hsi specs
         # consider include a diff if/else statement to handle ALWAYS IDEAL cases
-        #else:
+        # else:
         #    self._logger.info("Running SI 1")
         #    si_1 = np.full(self._shape, 999.0)
 
@@ -154,12 +155,12 @@ class GizzardShadHSI:
 
         # TODO: This will ALWAYS be set to ideal per hsi specs
         # consider include a diff if/else statement to handle ALWAYS IDEAL cases
-        #else:
+        # else:
         #    self._logger.info("Running SI 1")
         #    si_1 = np.full(self._shape, 999.0)
 
         return si_3
-    
+
     def calculate_si_4(self) -> np.ndarray:
         """MAXIMUM AVAILABLE DISSOLVED OXYGEN IN EPILIMNION DURING SUMMER STRATIFICATION."""
         # TMP: Set to ideal for HecRas only
@@ -174,14 +175,14 @@ class GizzardShadHSI:
 
         # TODO: this is a quick fix for hec-ras, need to implement the actual logic for other HH models
         # SI4 = 0, when V4 (ppm) ≤ 1
-	    # (0.2*V4) - 0.2, when 1 < V4 ≤ 6
-	    # 1, when V4 > 6
-        #else:
+        # (0.2*V4) - 0.2, when 1 < V4 ≤ 6
+        # 1, when V4 > 6
+        # else:
         #    self._logger.info("Running SI 1")
         #    si_1 = np.full(self._shape, 999.0)
 
         return si_4
-    
+
     def calculate_si_5(self) -> np.ndarray:
         """WATER LEVEL DURING SPAWNING SEASON AND EMBRYO DEVELOPMENT."""
         # Set to ideal
@@ -196,7 +197,7 @@ class GizzardShadHSI:
 
         # TODO: This will ALWAYS be set to ideal per hsi specs
         # consider include a diff if/else statement to handle ALWAYS IDEAL cases
-        #else:
+        # else:
         #    self._logger.info("Running SI 1")
         #    si_1 = np.full(self._shape, 999.0)
 
@@ -221,7 +222,7 @@ class GizzardShadHSI:
         # 1, when 15.8 < V6 ≤ 22.7
         # (-0.1923*V6) + 5.3654, when 22.7 < V6 ≤ 25.3
         # (-0.1064*V6) + 3.1915, when 25.3 < V6 ≤ 30.2
-        #else:
+        # else:
         #    self._logger.info("Running SI 1")
         #    si_1 = np.full(self._shape, 999.0)
 
@@ -231,7 +232,7 @@ class GizzardShadHSI:
         """% AREA VEGETATED AND ≤ 2m DEEP DURING SPAWNING SEASON."""
         # Use Curve A - Spawning season April-June in Upper Barataria
         self._logger.info("Running SI 7")
-        
+
         # for array in [
         #     self.v7a_pct_vegetated,
         #     self.v7b_water_depth_spawning_season,
@@ -242,33 +243,41 @@ class GizzardShadHSI:
         #         #si_7 = np.ones(self._shape)
 
         # Create an array to store the results
-        si_7 = np.full(self._shape, 0.0) #should thid be 999?
-        
+        si_7 = np.full(self._shape, 0.0)  # should thid be 999?
+
         # Note: equations use % values not decimals
         # self.v7a_pct_vegetated /= 100
-        
+
         # condition 1
-        mask_1 = (self.v7a_pct_vegetated <= 10) & (self.v7b_water_depth_spawning_season <= 2)
-        si_7[mask_1] = (0.08 * self.v7a_pct_vegetated[mask_1])
+        mask_1 = (self.v7a_pct_vegetated <= 10) & (
+            self.v7b_water_depth_spawning_season <= 2
+        )
+        si_7[mask_1] = 0.08 * self.v7a_pct_vegetated[mask_1]
 
         # condition 2
-        mask_2 = (self.v7a_pct_vegetated > 10) & (self.v7a_pct_vegetated <= 15) & (self.v7b_water_depth_spawning_season <= 2)
+        mask_2 = (
+            (self.v7a_pct_vegetated > 10)
+            & (self.v7a_pct_vegetated <= 15)
+            & (self.v7b_water_depth_spawning_season <= 2)
+        )
         si_7[mask_2] = (0.04 * self.v7a_pct_vegetated[mask_2]) + 0.4
 
         # condition 3 USE CURVE A
-        mask_3 = (self.v7a_pct_vegetated > 15) & (self.v7b_water_depth_spawning_season <= 2) #& (self.v7_pct_vegetated_and_2m_depth_spawning_season <= 30)
+        mask_3 = (self.v7a_pct_vegetated > 15) & (
+            self.v7b_water_depth_spawning_season <= 2
+        )  # & (self.v7_pct_vegetated_and_2m_depth_spawning_season <= 30)
         si_7[mask_3] = 1
 
-        mask_4 = (self.v7b_water_depth_spawning_season > 2)
+        mask_4 = self.v7b_water_depth_spawning_season > 2
         si_7[mask_4] = 0
-        
+
         # Create an array to store the results
-        #si_7 = np.full(self._shape, 999.0)
-        
+        # si_7 = np.full(self._shape, 999.0)
+
         # if self.v7b_water_depth_spawning_season.any() > 2.0:
         #     si_7 = np.zeros(self._shape) #is this right?
         # else:
-        #     #calc pct first, shorthand, yey. 
+        #     #calc pct first, shorthand, yey.
         #     self.v7a_pct_vegetated /= 100
         #     # condition 1
         #     mask_1 = self.v7a_pct_vegetated <= 10
@@ -316,12 +325,16 @@ class GizzardShadHSI:
 
         # TODO: may want to move these outside calculate_overall_suitability() into their own methods
         # so they can be accessed individually
-        food_component = self.si_1 # will be 1 for hec-ras
-        water_quality = np.minimum(self.si_3, self.si_4) * self.si_2 # will be 1 for hec-ras
+        food_component = self.si_1  # will be 1 for hec-ras
+        water_quality = (
+            np.minimum(self.si_3, self.si_4) * self.si_2
+        )  # will be 1 for hec-ras
         reproduction = (self.si_5 + self.si_6 + self.si_7) / 3
-        
-        #hsi = reproduction
-        hsi = np.minimum(food_component, np.minimum(water_quality, reproduction)) # will be reproduction for hec-ras
+
+        # hsi = reproduction
+        hsi = np.minimum(
+            food_component, np.minimum(water_quality, reproduction)
+        )  # will be reproduction for hec-ras
 
         # Note on np.minimum(): If one of the elements being compared is NaN (Not a Number), NaN is returned.
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -278,9 +278,6 @@ class GizzardShadHSI:
         mask_4 = self.v7b_water_depth_spawning_season > 2
         si_7[mask_4] = 0
 
-        # Create an array to store the results
-        # si_7 = np.full(self._shape, 999.0)
-
         # if self.v7b_water_depth_spawning_season.any() > 2.0:
         #     si_7 = np.zeros(self._shape) #is this right?
         # else:
@@ -299,8 +296,8 @@ class GizzardShadHSI:
         #     si_7[mask_3] = 1
 
         # Check for unhandled condition with tolerance
-        # if np.any(np.isclose(si_1, 999.0, atol=1e-5)):
-        #     raise ValueError("Unhandled condition in SI logic!")
+        if np.any(np.isclose(si_7, 999.0, atol=1e-5)):
+            raise ValueError("Unhandled condition in SI logic!")
 
         return si_7
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -278,23 +278,6 @@ class GizzardShadHSI:
         mask_4 = self.v7b_water_depth_spawning_season > 2
         si_7[mask_4] = 0
 
-        # if self.v7b_water_depth_spawning_season.any() > 2.0:
-        #     si_7 = np.zeros(self._shape) #is this right?
-        # else:
-        #     #calc pct first, shorthand, yey.
-        #     self.v7a_pct_vegetated /= 100
-        #     # condition 1
-        #     mask_1 = self.v7a_pct_vegetated <= 10
-        #     si_7[mask_1] = (0.08 * self.v7a_pct_vegetated[mask_1])
-
-        #     # condition 2
-        #     mask_2 = (self.v7a_pct_vegetated > 10) & (self.v7a_pct_vegetated <= 15)
-        #     si_7[mask_2] = (0.04 * self.v7a_pct_vegetated[mask_2]) + 0.4
-
-        #     # condition 3 USE CURVE A
-        #     mask_3 = self.v7a_pct_vegetated > 15 #& (self.v7_pct_vegetated_and_2m_depth_spawning_season <= 30)
-        #     si_7[mask_3] = 1
-
         # Check for unhandled condition with tolerance
         if np.any(np.isclose(si_7, 999.0, atol=1e-5)):
             raise ValueError("Unhandled condition in SI logic!")
@@ -341,7 +324,6 @@ class GizzardShadHSI:
         )  # will be reproduction for hec-ras
 
         # Note on np.minimum(): If one of the elements being compared is NaN (Not a Number), NaN is returned.
-
         # Check the final HSI array for invalid values
         invalid_values_hsi = (hsi < 0) | (hsi > 1)
         if np.any(invalid_values_hsi):

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -415,29 +415,39 @@ class VegTransition:
 
         Start and end parameters are year, and handled as ints. No other frequency currently possible.
         """
-        # run model forwards
-        # steps = int(self.simulation_duration / self.simulation_time_step)
-        self._logger.info(
-            "Starting simulation at %s. Period: %s - %s",
-            datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            self.water_year_start,
-            self.water_year_end,
-        )
+        # Store the default plotting backend
+        default_backend = plt.get_backend()
 
-        # plus 1 to make inclusive
-        simulation_period = range(self.water_year_start, self.water_year_end + 1)
+        try:
+            # change to non-gui backend to prevent
+            # memory leak if running in notebook
+            plt.switch_backend("Agg")
 
-        self._logger.info("Running model for: %s timesteps", len(simulation_period))
-
-        for i, wy in enumerate(simulation_period):
-            self.step(
-                timestep=pd.to_datetime(f"{wy}-10-01"),
-                counter=str(i + 1),
-                simulation_period=str(len(simulation_period)),
+            # run model forwards
+            # steps = int(self.simulation_duration / self.simulation_time_step)
+            self._logger.info(
+                "Starting simulation at %s. Period: %s - %s",
+                datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                self.water_year_start,
+                self.water_year_end,
             )
 
-        self._logger.info("Simulation complete")
-        logging.shutdown()
+            # plus 1 to make inclusive
+            simulation_period = range(self.water_year_start, self.water_year_end + 1)
+            self._logger.info("Running model for: %s timesteps", len(simulation_period))
+
+            for i, wy in enumerate(simulation_period):
+                self.step(
+                    timestep=pd.to_datetime(f"{wy}-10-01"),
+                    counter=str(i + 1),
+                    simulation_period=str(len(simulation_period)),
+                )
+
+            self._logger.info("Simulation complete")
+            logging.shutdown()
+
+        finally:
+            plt.switch_backend(default_backend)
 
     def _load_dem(self, cell: bool = False) -> np.ndarray:
         """Load project domain DEM.

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -591,15 +591,6 @@ class VegTransition:
         # so that areas outside of HECRAS domain are not classified as
         # dry (na is 0-filled above) when in fact that are outside of the domain.
         ds = ds.where(self.hecras_domain)
-
-        # ds["WSE_MEAN"].plot(
-        #     col="time",  # Create panels for each time step
-        #     col_wrap=4,  # Number of panels per row
-        #     cmap="viridis",
-        #     aspect=1.5,  # Adjust aspect ratio
-        #     size=3,  # Adjust figure size
-        # )
-        # plt.show()
         return ds
 
     def _calculate_maturity(self, veg_type_in: np.ndarray):

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -439,13 +439,27 @@ class VegTransition:
         self._logger.info("Simulation complete")
         logging.shutdown()
 
-    def _load_dem(self) -> np.ndarray:
-        """Load project domain DEM."""
+    def _load_dem(self, cell: bool = False) -> np.ndarray:
+        """Load project domain DEM.
+
+        Params
+        ------
+        cell : bool
+            If DEM should be downscaled to 480m cell size, default False
+
+        Return
+        ------
+        domain : np.ndarray
+            model domain in 60m or 480m resolution.
+        """
         ds = xr.open_dataset(self.dem_path)
         ds = ds.squeeze(drop="band_data")
         da = ds.to_dataarray(dim="band")
         self._logger.info("Loaded DEM")
-        # TODO: where is extra dim coming from? i.e. da[0] is needed!
+
+        if cell:
+            da = da.coarsen(y=8, x=8, boundary="pad").mean()
+
         return da[0].to_numpy()
 
     def load_wse_wy(


### PR DESCRIPTION
### 1. Standardize NaN handling for HSI models.

Now, new SI arrays are created by `_create_template_array()`

```
def _create_template_array(self) -> np.ndarray:
        """Create an array from a template all valid pixels are 999.0, and
        NaN from the input are persisted.
        """
        arr = np.where(np.isnan(self.v2_water_depth_annual_mean), np.nan, 999.0)
        return arr
```

`array` should be a depth array, i.e. one based on WSE if the species uses depth data, which will have NaN for areas outside the model domain. The template can also be the DEM, for cases where depth variables are not involved in the `SI` calculations. The initialization can have two possible outcomes:

1. If the SI logic is based on the depth array, the output will respect and inherit those NaN locations (i.e. the model domain)

2. If the SI logic is based on a non-depth related variable, such as percent coverage, the ruleset will overwrite the NaN locations with valid data, and the output array will have a SI value for all locations. In the case, the SI value will have output for the entire domain and is not limited to areas with hydrologic model output.

At the conclusion of the all SI functions, if any of the individual SI arrays are based on depth rules (and therefore have NaN) the final HSI function will respect those NaNs, and the HSI will inherit them. This is due to any `numpy` math containing a NaN resulting in Nan (i.e. `np.array[1, 3, np.nan] * 2 = np.array[2,6,np.nan]`). So the final HSI array will contain all pixels within the domain if no depth variables are used, or alternatively, a hydrologic model (HECRAS for now) cropped output if depth variables are used.

![bass_figs](https://github.com/user-attachments/assets/9e874b26-b9b9-404c-9a0b-55f9cc4ea9af)
In this example, the SI vars are all vegetation-based, so the HSI has coverage for the full veg domain

![alligator_figs](https://github.com/user-attachments/assets/4cb7148a-9514-45a3-967e-9b7f30e835f3)
In this example, SI_2 is depth based, so the final HSI is limited to the hydro domain.


### 2. Mask all HSI to vegetation domain. 
The final step in all HSI model is to mask the output to areas with vegetation type, i.e. the vegetation domain. This is accomplished with a new `HSI` class attribute `self.dem_480` which defines areas with vegetation type data. This is the "vegetation domain" (distinct from the hydrologic or HECRAS domain).

### 3. Centralize calculation of depth from WSE
Now all depth arrays rely on `VegTransition._get_depth()`, with `HSI._get_depth_filtered()` calling the parent method and then add a filtering and downscaling step. This prevents any issues where depth is calculated different in `VegTransition` and `HSI` (which was previously occurring). 

`HSI._get_depth_filtered` now includes an arg where the months to average over are supplied in a dict:
https://github.com/LynkerIntel/cpra-hsi/blob/0dd11266b1a975691ce5d9262fab2c3955ba843e/VegProcessor/hsi.py#L246-L248

### 4. Add `safe_divide()` method
decimal or percent handling is now included in the `from_hsi()` class method. This is a bit tidier, and ensures that the arrays passed to each `si_x` function do not need to be updated or changed before applying the SI logic.
https://github.com/LynkerIntel/cpra-hsi/blob/27ff63c0449ab93f7fb050eb79735895e94cc55c/VegProcessor/species_hsi/alligator.py#L41-L62

### 5. Remove missing data handling for percent cover.
Loops that check for missing percent cover data are removed, because (1) there must be vegetation cover data in order to run `HSI`, and (2) the "ideal" array is assigned to the temporary var `array` which is defined in the loop, and is not actually persisted--whoops.
```
for array in [
            self.v3a_pct_cell_swamp_bottomland_hardwood,
            self.v3b_pct_cell_fresh_marsh,
            self.v3c_pct_cell_open_water,
            self.v3d_pct_cell_intermediate_marsh,
            self.v3e_pct_cell_brackish_marsh,
            self.v3f_pct_cell_saline_marsh,
            self.v3g_pct_cell_bare_ground,
        ]:
            if array is None:
                self._logger.info("%s data not provided. Setting index to 1", array)
                array = np.ones(self._shape)
 ```
