### PR TITLE
Updates to Gizzard Shad HSI

### DIFF
--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -210,24 +210,51 @@ class GizzardShadHSI:
         # initialize with NaN from depth array, else 999
         si_3 = self.template.copy()
 
-        # Set to ideal for HecRas only (25 degrees C)
+        # Set to ideal 
         if self.v3_mean_weekly_summer_temp is None:
-            # self._logger.info(
-            #     "mean weekly summer temperature data not provided. Setting index to 1."
-            # )
             self._logger.info(
-                "mean weekly summer temperature data assumes ideal conditions (25 degrees) for HEC-RAS. Setting index to 1."
+                "mean weekly summer temperature data assumes ideal conditions. Setting index to 1."
             )
             si_3[~np.isnan(si_3)] = 1
 
-        # TODO: This will ALWAYS be set to ideal per hsi specs
-        # consider include a diff if/else statement to handle ALWAYS IDEAL cases
-        # else:
-        #    self._logger.info("Running SI 1")
-        #    si_1 = np.full(self._shape, 999.0)
+        else:
+            # condition 1
+            mask_1 = (self.v3_mean_weekly_summer_temp >= 15) & (
+                self.v3_mean_weekly_summer_temp < 18.5
+            )
+            si_3[mask_1] = (
+                0.0286 * (self.v3_mean_weekly_summer_temp[mask_1])
+            ) - 0.4286
 
-        # if self.hydro_domain_flag:
-        #         si_3 = np.where(~np.isnan(self.hydro_domain_480), si_3, np.nan)
+            # condition 2
+            mask_2 = (self.v3_mean_weekly_summer_temp >= 18.5) & (
+                self.v3_mean_weekly_summer_temp < 22
+            )
+            si_3[mask_2] = (
+                0.2571 * (self.v3_mean_weekly_summer_temp[mask_2])
+            ) - 4.6571
+
+            # condition 3
+            mask_3 = (self.v3_mean_weekly_summer_tempn >= 22) & (
+                self.v3_mean_weekly_summer_temp <= 29
+            )
+            si_3[mask_3] = 1
+
+            # condition 4
+            mask_4 = (self.v3_mean_weekly_summer_tempn > 29) & (
+                self.v3_mean_weekly_summer_temp < 33
+            )
+            si_3[mask_4] = (
+                -0.1875 * (self.v3_mean_weekly_summer_temp[mask_4])
+            ) + 6.4375
+
+            # condition 5
+            mask_5 = (self.v3_mean_weekly_summer_temp >= 33) & (
+                self.v3_mean_weekly_summer_temp <= 35
+            )
+            si_3[mask_5] = (
+                -0.1 * (self.v3_mean_weekly_summer_temp[mask_5])
+            ) + 3.55
 
         return si_3
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -121,20 +121,40 @@ class GizzardShadHSI:
 
         # Set to ideal – there is no food limitation
         if self.v1_tds_summer_growing_season is None:
-            # self._logger.info("TDS during summer growing season data not provided. Setting index to 1.")
             self._logger.info(
                 "TDS during summer growing season data assumes ideal conditions. Setting index to 1."
             )
             si_1[~np.isnan(si_1)] = 1
 
-        # TODO: This will ALWAYS be set to ideal per hsi specs
-        # consider include a diff if/else statement to handle ALWAYS IDEAL cases
-        # else:
-        #    self._logger.info("Running SI 1")
-        #    si_1 = np.full(self._shape, 999.0)
+        else: 
+            # condition 1
+            mask_1 = (self.v1_tds_summer_growing_season >= 0) & (
+                self.v1_tds_summer_growing_season < 1.2
+            )
+            si_1[mask_1] = 0.0833 * self.v1_tds_summer_growing_season[mask_1]
 
-        # if self.hydro_domain_flag:
-        #         si_1 = np.where(~np.isnan(self.hydro_domain_480), si_1, np.nan)
+            # condition 2
+            mask_2 = (self.v1_tds_summer_growing_season >= 1.2) & (
+                self.v1_tds_summer_growing_season < 3
+            )
+            si_1[mask_2] = (
+                0.5 * (self.v1_tds_summer_growing_season[mask_2])
+            ) - 0.5
+
+            # condition 3
+            mask_3 = (self.v1_tds_summer_growing_season >= 3) & (
+                self.v1_tds_summer_growing_season < 4
+            )
+            si_1[mask_3] = (
+                -1 * (self.v1_tds_summer_growing_season[mask_3])
+            ) + 4
+
+            # condition 4
+            mask_4 = self.v1_tds_summer_growing_season > 4
+            si_1[mask_4] = 0
+
+        if np.any(np.isclose(si_1, 999.0, atol=1e-5)):
+            raise ValueError("Unhandled condition in SI logic!")
 
         return si_1
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -26,7 +26,7 @@ class GizzardShadHSI:
     v3_mean_weekly_summer_temp: np.ndarray = None  # ideal
     v4_max_do_summer: np.ndarray = None  # ideal
     v5a_water_lvl_change: np.ndarray = None  # ideal
-    v5b_is_veg_inundated: np.ndarray = None #ideal
+    v5b_is_veg_inundated: np.ndarray = None  # ideal
     v6_mean_weekly_temp_reservoir_spawning_season: np.ndarray = None  # ideal
     v7a_pct_vegetated: np.ndarray = None
     v7b_water_depth_spawning_season: np.ndarray = None
@@ -40,7 +40,6 @@ class GizzardShadHSI:
     si_6: np.ndarray = field(init=False)
     si_7: np.ndarray = field(init=False)
 
-    
     # Set up components and equations
     food_component: np.ndarray = field(init=False)
     water_quality: np.ndarray = field(init=False)
@@ -127,7 +126,7 @@ class GizzardShadHSI:
             )
             si_1[~np.isnan(si_1)] = 1
 
-        else: 
+        else:
             # condition 1
             mask_1 = (self.v1_tds_summer_growing_season >= 0) & (
                 self.v1_tds_summer_growing_season < 1.2
@@ -181,23 +180,26 @@ class GizzardShadHSI:
                 self.v2_avg_num_frost_free_days_growing_season < 105
             )
             si_2[mask_1] = (
-                0.002 * (self.v2_avg_num_frost_free_days_growing_season[mask_1])
+                0.002
+                * (self.v2_avg_num_frost_free_days_growing_season[mask_1])
             ) - 0.11
 
             # condition 2
-            mask_2 = (self.v2_avg_num_frost_free_days_growing_season >= 105) & (
-                self.v2_avg_num_frost_free_days_growing_season < 245
-            )
+            mask_2 = (
+                self.v2_avg_num_frost_free_days_growing_season >= 105
+            ) & (self.v2_avg_num_frost_free_days_growing_season < 245)
             si_2[mask_2] = (
-                0.0061 * (self.v2_avg_num_frost_free_days_growing_season[mask_2])
+                0.0061
+                * (self.v2_avg_num_frost_free_days_growing_season[mask_2])
             ) - 0.5375
 
             # condition 3
-            mask_3 = (self.v2_avg_num_frost_free_days_growing_season >= 245) & (
-                self.v2_avg_num_frost_free_days_growing_season <= 265
-            )
+            mask_3 = (
+                self.v2_avg_num_frost_free_days_growing_season >= 245
+            ) & (self.v2_avg_num_frost_free_days_growing_season <= 265)
             si_2[mask_3] = (
-                0.0019 * (self.v2_avg_num_frost_free_days_growing_season[mask_3])
+                0.0019
+                * (self.v2_avg_num_frost_free_days_growing_season[mask_3])
             ) + 0.4963
 
             # condition 4
@@ -206,7 +208,7 @@ class GizzardShadHSI:
 
         if np.any(np.isclose(si_2, 999.0, atol=1e-5)):
             raise ValueError("Unhandled condition in SI logic!")
-        
+
         return si_2
 
     def calculate_si_3(self) -> np.ndarray:
@@ -215,7 +217,7 @@ class GizzardShadHSI:
         # initialize with NaN from depth array, else 999
         si_3 = self.template.copy()
 
-        # Set to ideal 
+        # Set to ideal
         if self.v3_mean_weekly_summer_temp is None:
             self._logger.info(
                 "Mean weekly summer temperature data assumes ideal conditions. Setting index to 1."
@@ -246,7 +248,7 @@ class GizzardShadHSI:
             si_3[mask_3] = 1
 
             # condition 4
-            mask_4 = (self.v3_mean_weekly_summer_tempn > 29) & (
+            mask_4 = (self.v3_mean_weekly_summer_temp > 29) & (
                 self.v3_mean_weekly_summer_temp < 33
             )
             si_3[mask_4] = (
@@ -269,7 +271,7 @@ class GizzardShadHSI:
 
         if np.any(np.isclose(si_3, 999.0, atol=1e-5)):
             raise ValueError("Unhandled condition in SI logic!")
-        
+
         return si_3
 
     def calculate_si_4(self) -> np.ndarray:
@@ -279,7 +281,7 @@ class GizzardShadHSI:
 
         if self.v4_max_do_summer is None:
             self._logger.info(
-                "Maximum available dissolved oxygen in epilimnion during summer stratification"
+                "Maximum available dissolved oxygen in epilimnion during summer stratification "
                 "is not provided. Setting index to 1."
             )
             si_4[~np.isnan(si_4)] = 1
@@ -290,12 +292,8 @@ class GizzardShadHSI:
             si_4[mask_1] = 0
 
             # condition 2
-            mask_2 = (self.v4_max_do_summer > 1) & (
-                self.v4_max_do_summer < 6
-            )
-            si_4[mask_2] = (
-                0.2 * (self.v4_max_do_summer[mask_2])
-            ) - 0.2
+            mask_2 = (self.v4_max_do_summer > 1) & (self.v4_max_do_summer < 6)
+            si_4[mask_2] = (0.2 * (self.v4_max_do_summer[mask_2])) - 0.2
 
             # condition 3
             mask_3 = self.v4_max_do_summer > 6
@@ -332,9 +330,11 @@ class GizzardShadHSI:
             si_5[mask_2] = 0.8
 
             # condition 3: level = 3, decline (negative change) in wl <= 0.5m
-            mask_3 = (self.v5a_water_lvl_change >= -0.5) & (
-                self.v5a_water_lvl_change < 0 
-            ) & (self.v5b_is_veg_inundated == True)
+            mask_3 = (
+                (self.v5a_water_lvl_change >= -0.5)
+                & (self.v5a_water_lvl_change < 0)
+                & (self.v5b_is_veg_inundated == True)
+            )
             si_5[mask_3] = 0.5
 
             # condition 4: level = 4, decline (negative change) in wl > 0.5m
@@ -345,7 +345,7 @@ class GizzardShadHSI:
 
         if np.any(np.isclose(si_5, 999.0, atol=1e-5)):
             raise ValueError("Unhandled condition in SI logic!")
-        
+
         return si_5
 
     def calculate_si_6(self) -> np.ndarray:
@@ -359,42 +359,45 @@ class GizzardShadHSI:
             )
             si_6[~np.isnan(si_6)] = 1
 
-        else: 
+        else:
             # condition 1
             mask_1 = self.v6_mean_weekly_temp_reservoir_spawning_season <= 10.9
             si_6[mask_1] = 0
 
             # condition 2
-            mask_2 = (self.v6_mean_weekly_temp_reservoir_spawning_season > 10.9) & (
-                self.v6_mean_weekly_temp_reservoir_spawning_season <= 15.8
-            )
+            mask_2 = (
+                self.v6_mean_weekly_temp_reservoir_spawning_season > 10.9
+            ) & (self.v6_mean_weekly_temp_reservoir_spawning_season <= 15.8)
             si_6[mask_2] = (
-                0.2041 * (self.v6_mean_weekly_temp_reservoir_spawning_season[mask_2])
+                0.2041
+                * (self.v6_mean_weekly_temp_reservoir_spawning_season[mask_2])
             ) - 2.2245
 
             # condition 3
-            mask_3 =  (self.v6_mean_weekly_temp_reservoir_spawning_season > 15.8) & (
-                self.v6_mean_weekly_temp_reservoir_spawning_season <= 22.7
-            )
+            mask_3 = (
+                self.v6_mean_weekly_temp_reservoir_spawning_season > 15.8
+            ) & (self.v6_mean_weekly_temp_reservoir_spawning_season <= 22.7)
             si_6[mask_3] = 1
 
             # condition 4
-            mask_4 = (self.v6_mean_weekly_temp_reservoir_spawning_season > 22.7) & (
-                self.v6_mean_weekly_temp_reservoir_spawning_season <= 25.3
-            )
+            mask_4 = (
+                self.v6_mean_weekly_temp_reservoir_spawning_season > 22.7
+            ) & (self.v6_mean_weekly_temp_reservoir_spawning_season <= 25.3)
             si_6[mask_4] = (
-                -0.1923 * (self.v6_mean_weekly_temp_reservoir_spawning_season[mask_4])
+                -0.1923
+                * (self.v6_mean_weekly_temp_reservoir_spawning_season[mask_4])
             ) + 5.3654
 
             # condition 5
-            mask_5 = (self.v6_mean_weekly_temp_reservoir_spawning_season > 25.3) & (
-                self.v6_mean_weekly_temp_reservoir_spawning_season <= 30
-            )
+            mask_5 = (
+                self.v6_mean_weekly_temp_reservoir_spawning_season > 25.3
+            ) & (self.v6_mean_weekly_temp_reservoir_spawning_season <= 30)
             si_6[mask_5] = (
-                -0.1064 * (self.v6_mean_weekly_temp_reservoir_spawning_season[mask_5])
+                -0.1064
+                * (self.v6_mean_weekly_temp_reservoir_spawning_season[mask_5])
             ) + 3.1915
 
-            # condition 6 
+            # condition 6
             mask_6 = self.v6_mean_weekly_temp_reservoir_spawning_season > 30
             si_6[mask_6] = 0
 
@@ -405,7 +408,7 @@ class GizzardShadHSI:
 
     def calculate_si_7(self) -> np.ndarray:
         """% AREA VEGETATED AND ≤ 2m DEEP DURING SPAWNING SEASON (APR - JUN)."""
-     
+
         self._logger.info("Running SI 7")
         si_7 = self.template.copy()
 
@@ -462,15 +465,14 @@ class GizzardShadHSI:
 
         # individual model components
         self.food_component = self.si_1  # will be 1 for hec-ras
-        self.water_quality = (
-            np.minimum(self.si_3, self.si_4) * self.si_2
-        )  
+        self.water_quality = np.minimum(self.si_3, self.si_4) * self.si_2
         self.reproduction = (self.si_5 + self.si_6 + self.si_7) / 3
 
         # combine individual suitability indices
         hsi = np.minimum(
-            self.food_component, np.minimum(self.water_quality, self.reproduction)
-        )  
+            self.food_component,
+            np.minimum(self.water_quality, self.reproduction),
+        )
 
         # Note on np.minimum(): If one of the elements being compared is NaN (Not a Number), NaN is returned.
         # Check the final HSI array for invalid values

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -160,14 +160,14 @@ class GizzardShadHSI:
         return si_1
 
     def calculate_si_2(self) -> np.ndarray:
-        """GROWING SEASON (AVERAGE NUMBER OF DAYS BETWEEN LAST SPRING AND FIRST FALL FROST ANUALLY."""
+        """GROWING SEASON AVERAGE NUMBER OF DAYS BETWEEN LAST SPRING AND FIRST FALL FROST ANUALLY."""
         self._logger.info("Running SI 2")
         si_2 = self.template.copy()
 
         # Set to Ideal
         if self.v2_avg_num_frost_free_days_growing_season is None:
             self._logger.info(
-                "avg num of frost free days in growing season data assumes ideal conditions. Setting index to 1."
+                "Avg num of frost free days in growing season data assumes ideal conditions. Setting index to 1."
             )
             si_2[~np.isnan(si_2)] = 1
 
@@ -218,7 +218,7 @@ class GizzardShadHSI:
         # Set to ideal 
         if self.v3_mean_weekly_summer_temp is None:
             self._logger.info(
-                "mean weekly summer temperature data assumes ideal conditions. Setting index to 1."
+                "Mean weekly summer temperature data assumes ideal conditions. Setting index to 1."
             )
             si_3[~np.isnan(si_3)] = 1
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -298,14 +298,12 @@ class GizzardShadHSI:
         return si_6
 
     def calculate_si_7(self) -> np.ndarray:
-        """% AREA VEGETATED AND ≤ 2m DEEP DURING SPAWNING SEASON."""
-        # Use Curve A - Spawning season April-June in Upper Barataria
+        """% AREA VEGETATED AND ≤ 2m DEEP DURING SPAWNING SEASON (APR - JUN)."""
+     
         self._logger.info("Running SI 7")
         si_7 = self.template.copy()
 
-        # Note: equations use % values not decimals
-        # self.v7a_pct_vegetated /= 100
-
+        # use Curve A
         # condition 1
         mask_1 = (self.v7a_pct_vegetated <= 10) & (
             self.v7b_water_depth_spawning_season <= 2
@@ -320,21 +318,18 @@ class GizzardShadHSI:
         )
         si_7[mask_2] = (0.04 * self.v7a_pct_vegetated[mask_2]) + 0.4
 
-        # condition 3 USE CURVE A
+        # condition 3
         mask_3 = (self.v7a_pct_vegetated > 15) & (
             self.v7b_water_depth_spawning_season <= 2
-        )  # & (self.v7_pct_vegetated_and_2m_depth_spawning_season <= 30)
+        )
         si_7[mask_3] = 1
 
+        # condition 4
         mask_4 = self.v7b_water_depth_spawning_season > 2
         si_7[mask_4] = 0
 
-        # Check for unhandled condition with tolerance
         if np.any(np.isclose(si_7, 999.0, atol=1e-5)):
             raise ValueError("Unhandled condition in SI logic!")
-
-        # if self.hydro_domain_flag:
-        #         si_7 = np.where(~np.isnan(self.hydro_domain_480), si_7, np.nan)
 
         return si_7
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -263,7 +263,7 @@ class GizzardShadHSI:
 
             # condition 6
             mask_6 = (self.v3_mean_weekly_summer_temp < 15) | (
-                self.v3_mean_weekly_summer_temp > 30
+                self.v3_mean_weekly_summer_temp > 35
             )
             si_3[mask_6] = 0
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -172,6 +172,10 @@ class GizzardShadHSI:
             si_2[~np.isnan(si_2)] = 1
 
         else:
+            # condition 0
+            mask_0 = self.v2_avg_num_frost_free_days_growing_season < 80
+            si_2[mask_0] = 0
+
             # condition 1
             mask_1 = (self.v2_avg_num_frost_free_days_growing_season >= 80) & (
                 self.v2_avg_num_frost_free_days_growing_season < 105

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -394,6 +394,10 @@ class GizzardShadHSI:
                 -0.1064 * (self.v6_mean_weekly_temp_reservoir_spawning_season[mask_5])
             ) + 3.1915
 
+            # condition 6 
+            mask_6 = self.v6_mean_weekly_temp_reservoir_spawning_season > 30
+            si_6[mask_6] = 0
+
         if np.any(np.isclose(si_6, 999.0, atol=1e-5)):
             raise ValueError("Unhandled condition in SI logic!")
 

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -236,7 +236,7 @@ class GizzardShadHSI:
             ) - 4.6571
 
             # condition 3
-            mask_3 = (self.v3_mean_weekly_summer_tempn >= 22) & (
+            mask_3 = (self.v3_mean_weekly_summer_temp >= 22) & (
                 self.v3_mean_weekly_summer_temp <= 29
             )
             si_3[mask_3] = 1
@@ -257,6 +257,15 @@ class GizzardShadHSI:
                 -0.1 * (self.v3_mean_weekly_summer_temp[mask_5])
             ) + 3.55
 
+            # condition 6
+            mask_6 = (self.v3_mean_weekly_summer_temp < 15) | (
+                self.v3_mean_weekly_summer_temp > 30
+            )
+            si_3[mask_6] = 0
+
+        if np.any(np.isclose(si_3, 999.0, atol=1e-5)):
+            raise ValueError("Unhandled condition in SI logic!")
+        
         return si_3
 
     def calculate_si_4(self) -> np.ndarray:

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -40,6 +40,12 @@ class GizzardShadHSI:
     si_6: np.ndarray = field(init=False)
     si_7: np.ndarray = field(init=False)
 
+    
+    # Set up components and equations
+    food_component: np.ndarray = field(init=False)
+    water_quality: np.ndarray = field(init=False)
+    reproduction: np.ndarray = field(init=False)
+
     # Overall Habitat Suitability Index (HSI)
     hsi: np.ndarray = field(init=False)
 
@@ -354,23 +360,17 @@ class GizzardShadHSI:
                     num_invalid,
                 )
 
-        # Set up components and equations
-        food_component: np.ndarray = field(init=False)
-        water_quality: np.ndarray = field(init=False)
-        reproduction: np.ndarray = field(init=False)
-
-        # TODO: may want to move these outside calculate_overall_suitability() into their own methods
-        # so they can be accessed individually
-        food_component = self.si_1  # will be 1 for hec-ras
-        water_quality = (
+        # individual model components
+        self.food_component = self.si_1  # will be 1 for hec-ras
+        self.water_quality = (
             np.minimum(self.si_3, self.si_4) * self.si_2
-        )  # will be 1 for hec-ras
-        reproduction = (self.si_5 + self.si_6 + self.si_7) / 3
+        )  
+        self.reproduction = (self.si_5 + self.si_6 + self.si_7) / 3
 
-        # hsi = reproduction
+        # combine individual suitability indices
         hsi = np.minimum(
-            food_component, np.minimum(water_quality, reproduction)
-        )  # will be reproduction for hec-ras
+            self.food_component, np.minimum(self.water_quality, self.reproduction)
+        )  
 
         # Note on np.minimum(): If one of the elements being compared is NaN (Not a Number), NaN is returned.
         # Check the final HSI array for invalid values

--- a/VegProcessor/species_hsi/gizzardshad.py
+++ b/VegProcessor/species_hsi/gizzardshad.py
@@ -318,14 +318,14 @@ class GizzardShadHSI:
 
         else:
             # condition 1: level = 1, rising water levels (wl) and inundated veg
-            mask_1 = (self.v5a_water_lvl_change > 0) & (
-                (self.v5b_is_veg_inundated == True)
-            )
+            mask_1 = (
+                self.v5a_water_lvl_change > 0
+            ) & self.v5b_is_veg_inundated
             si_5[mask_1] = 1
 
             # condition 2: level = 2, stable wl or no inundated veg
             mask_2 = (self.v5a_water_lvl_change == 0) | (
-                (self.v5b_is_veg_inundated == False)
+                ~self.v5b_is_veg_inundated
             )
             si_5[mask_2] = 0.8
 
@@ -333,14 +333,14 @@ class GizzardShadHSI:
             mask_3 = (
                 (self.v5a_water_lvl_change >= -0.5)
                 & (self.v5a_water_lvl_change < 0)
-                & (self.v5b_is_veg_inundated == True)
+                & self.v5b_is_veg_inundated
             )
             si_5[mask_3] = 0.5
 
             # condition 4: level = 4, decline (negative change) in wl > 0.5m
-            mask_4 = (self.v5a_water_lvl_change < -0.5) & (
-                self.v5b_is_veg_inundated == True
-            )
+            mask_4 = (
+                self.v5a_water_lvl_change < -0.5
+            ) & self.v5b_is_veg_inundated
             si_5[mask_4] = 0.2
 
         if np.any(np.isclose(si_5, 999.0, atol=1e-5)):


### PR DESCRIPTION
This pull request introduces updates to the Gizzard Shad HSI model, primarily to address missing logic and resolves #46 (Gizzard Shad Cleanup).

Specifically, this PR:
* Includes logic for SI4 and SI6, which are not set to ideal for non-HEC-RAS models.
* Includes logic for SI1, SI2, SI3, and SI5, which are set to ideal for all models.
* Provides edits to SI7, which is not set to ideal.
* Moves individual components (reproduction, water quality, food component) outside of `calculate_overall_suitability()` so they can be accessed directly from the HSI class.
* Cleans up comments.