### PR TITLE
Low Water Refuge and Flood Pulse Metrics

### DIFF
--- a/VegProcessor/output_vars.py
+++ b/VegProcessor/output_vars.py
@@ -1062,8 +1062,12 @@ def get_hsi_480m_variables(hsi):
             {
                 "grid_mapping": "spatial_ref",
                 "units": "meters",
-                "long_name": "Mean annual water depth relative to marsh surface",
-                "description": "Mean annual WSE minus mean elevation of vegetated pixels per cell",
+                "long_name": (
+                    "Mean annual water depth relative to marsh surface"
+                ),
+                "description": (
+                    "Mean annual WSE minus mean elevation of vegetated pixels per cell"
+                ),
             },
         ],
         "water_depth_jan_aug_mean": [
@@ -1152,7 +1156,9 @@ def get_hsi_480m_variables(hsi):
             {
                 "grid_mapping": "spatial_ref",
                 "units": "mg/L",
-                "long_name": "suspended sediment max monthly mean July-September",
+                "long_name": (
+                    "suspended sediment max monthly mean July-September"
+                ),
                 "description": (
                     "Maximum of monthly-mean suspended sediment concentration "
                     "for July-September period at 480m resolution"
@@ -1753,6 +1759,15 @@ def get_veg_variables(veg):
                 "grid_mapping": "spatial_ref",
                 "units": "ppt",
                 "long_name": "water salinity",
+            },
+        ],
+        "flood_pulse": [
+            veg.flood_pulse,
+            np.int8,
+            {
+                "grid_mapping": "spatial_ref",
+                "units": "binary",
+                "long_name": "Flood Pulse Inundation",
             },
         ],
         # QC variables below

--- a/VegProcessor/output_vars.py
+++ b/VegProcessor/output_vars.py
@@ -1779,6 +1779,16 @@ def get_veg_variables(veg):
                 "long_name": "low water refuge",
             },
         ],
+        "flooded": [
+            veg.flooded,
+            np.float32,
+            {
+                "grid_mapping": "spatial_ref",
+                "units": "binary",
+                "long_name": "is flooded",
+                "description": "1=Flooded at any point in WY (>5cm), 0=Dry",
+            },
+        ],
         # QC variables below
         "qc_annual_mean_salinity": [
             veg.qc_annual_mean_salinity,

--- a/VegProcessor/output_vars.py
+++ b/VegProcessor/output_vars.py
@@ -1767,7 +1767,16 @@ def get_veg_variables(veg):
             {
                 "grid_mapping": "spatial_ref",
                 "units": "binary",
-                "long_name": "Flood Pulse Inundation",
+                "long_name": "flood pulse inundation",
+            },
+        ],
+        "low_water_refuge": [
+            veg.low_water_refuge,
+            np.int8,
+            {
+                "grid_mapping": "spatial_ref",
+                "units": "binary",
+                "long_name": "low water refuge",
             },
         ],
         # QC variables below

--- a/VegProcessor/output_vars.py
+++ b/VegProcessor/output_vars.py
@@ -1763,7 +1763,7 @@ def get_veg_variables(veg):
         ],
         "flood_pulse": [
             veg.flood_pulse,
-            np.int8,
+            np.float32,
             {
                 "grid_mapping": "spatial_ref",
                 "units": "binary",
@@ -1772,7 +1772,7 @@ def get_veg_variables(veg):
         ],
         "low_water_refuge": [
             veg.low_water_refuge,
-            np.int8,
+            np.float32,
             {
                 "grid_mapping": "spatial_ref",
                 "units": "binary",

--- a/VegProcessor/output_vars.py
+++ b/VegProcessor/output_vars.py
@@ -1767,7 +1767,7 @@ def get_veg_variables(veg):
             {
                 "grid_mapping": "spatial_ref",
                 "units": "binary",
-                "long_name": "flood pulse inundation",
+                "long_name": "flood pulse extent",
             },
         ],
         "low_water_refuge": [
@@ -1776,17 +1776,7 @@ def get_veg_variables(veg):
             {
                 "grid_mapping": "spatial_ref",
                 "units": "binary",
-                "long_name": "low water refuge",
-            },
-        ],
-        "flooded": [
-            veg.flooded,
-            np.float32,
-            {
-                "grid_mapping": "spatial_ref",
-                "units": "binary",
-                "long_name": "is flooded",
-                "description": "1=Flooded at any point in WY (>5cm), 0=Dry",
+                "long_name": "low water refuge extent",
             },
         ],
         # QC variables below

--- a/VegProcessor/output_vars.py
+++ b/VegProcessor/output_vars.py
@@ -1062,12 +1062,8 @@ def get_hsi_480m_variables(hsi):
             {
                 "grid_mapping": "spatial_ref",
                 "units": "meters",
-                "long_name": (
-                    "Mean annual water depth relative to marsh surface"
-                ),
-                "description": (
-                    "Mean annual WSE minus mean elevation of vegetated pixels per cell"
-                ),
+                "long_name": "Mean annual water depth relative to marsh surface",
+                "description": "Mean annual WSE minus mean elevation of vegetated pixels per cell",
             },
         ],
         "water_depth_jan_aug_mean": [
@@ -1156,13 +1152,9 @@ def get_hsi_480m_variables(hsi):
             {
                 "grid_mapping": "spatial_ref",
                 "units": "mg/L",
-                "long_name": (
-                    "suspended sediment max monthly mean July-September"
-                ),
-                "description": (
-                    "Maximum of monthly-mean suspended sediment concentration "
-                    "for July-September period at 480m resolution"
-                ),
+                "long_name": "suspended sediment max monthly mean July-September",
+                "description": "Maximum of monthly-mean suspended sediment concentration "
+                "for July-September period at 480m resolution",
             },
         ],
         "pct_pools_july_sept_mean": [

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -233,6 +233,52 @@ def load_mf_tifs(
     return xr_dataset
 
 
+def get_raster_value_at_point(
+    raster_path: str, x: float, y: float, target_crs: str = "EPSG:26915"
+) -> float:
+    """
+    Extracts a single numeric value from a raster at a specific coordinate.
+
+    This is specifically used for gage lookups (e.g., Butte LaRose) to establish
+    a ground elevation baseline for flood pulse metrics.
+
+    Parameters
+    ----------
+    raster_path : str
+        Path to the .tif file.
+    x : float
+        Easting or Longitude coordinate.
+    y : float
+        Northing or Latitude coordinate.
+    target_crs : str
+        The expected CRS of the input coordinates (default UTM Zone 15N).
+
+    Returns
+    -------
+    float
+        The cell value at the nearest neighbor to the provided coordinates.
+    """
+    with xr.open_dataset(raster_path) as ds:
+        # Get the first data variable (handles 'band_data', 'Band1', etc.)
+        da = ds[list(ds.data_vars.keys())[0]]
+
+        # CRS Check
+        if da.rio.crs and str(da.rio.crs).upper() != target_crs.upper():
+            logger.info(
+                f"CRS mismatch: Raster is {da.rio.crs} "
+                f"but point coords are {target_crs}."
+            )
+
+        try:
+            # Nearest neighbor selection
+            return float(da.sel(x=x, y=y, method="nearest").item())
+        except Exception as e:
+            logger.info(
+                f"Point lookup failed at ({x}, {y}) in {raster_path}: {e}"
+            )
+            return float("nan")
+
+
 def coarsen_and_reduce(
     da: xr.DataArray, veg_type: int | bool, **kwargs
 ) -> xr.DataArray:
@@ -599,33 +645,43 @@ def wpu_sums(ds_veg: xr.Dataset, zones: xr.DataArray) -> pd.DataFrame:
 
     return df_out
 
+
 def wpu_hsi_means(ds_hsi: xr.Dataset, wpu_grid: xr.DataArray) -> pd.DataFrame:
     """Computes annual mean scores for HSI/SI variables grouped by WPU."""
 
     hsi_vars = [
-        var for var in ds_hsi.data_vars if '_hsi' in var.lower() or '_si_' in var.lower()]
-    
+        var
+        for var in ds_hsi.data_vars
+        if "_hsi" in var.lower() or "_si_" in var.lower()
+    ]
+
     if not hsi_vars:
         return pd.DataFrame()
 
     # Downsamples the 60m WPU grid to the 480m HSI grid
     zonal_ids = wpu_grid.rio.reproject_match(ds_hsi).compute()
-    zonal_ids.name = "wpu" 
-    
+    zonal_ids.name = "wpu"
+
     zonal_ids = xr.where(zonal_ids > 0, zonal_ids, np.nan)
 
     ds_zonal_means = ds_hsi[hsi_vars].groupby(zonal_ids).mean()
     df_timeseries = ds_zonal_means.to_dataframe().reset_index()
-    
-    if 'time' in df_timeseries.columns:
-        df_timeseries.rename(columns={'time': 'timestep'}, inplace=True)
-    
-    df_timeseries = df_timeseries.dropna(subset=['wpu'])
-    df_timeseries['wpu'] = df_timeseries['wpu'].astype(int)
-    
-    cols = ['timestep', 'wpu'] + [c for c in df_timeseries.columns if c not in ['timestep', 'wpu']]
-    
-    return df_timeseries[cols].sort_values(['timestep', 'wpu']).reset_index(drop=True)
+
+    if "time" in df_timeseries.columns:
+        df_timeseries.rename(columns={"time": "timestep"}, inplace=True)
+
+    df_timeseries = df_timeseries.dropna(subset=["wpu"])
+    df_timeseries["wpu"] = df_timeseries["wpu"].astype(int)
+
+    cols = ["timestep", "wpu"] + [
+        c for c in df_timeseries.columns if c not in ["timestep", "wpu"]
+    ]
+
+    return (
+        df_timeseries[cols]
+        .sort_values(["timestep", "wpu"])
+        .reset_index(drop=True)
+    )
 
 
 def generate_filename(
@@ -1375,9 +1431,7 @@ def save_variables_as_cogs(
             max_value = float(da_slice.max().values)
             units = da_slice.attrs.get("units", "")
 
-            output_path = os.path.join(
-                var_dir, f"{var_name}_{file_label}.tif"
-            )
+            output_path = os.path.join(var_dir, f"{var_name}_{file_label}.tif")
             if not overwrite and os.path.exists(output_path):
                 print(f"  skipping existing file: {output_path}")
                 continue
@@ -1457,9 +1511,7 @@ def process_netcdf_folder(
                 if ds[var_name].dtype == bool or str(
                     ds[var_name].dtype
                 ).startswith("bool"):
-                    print(
-                        f"converting boolean variable {var_name} to uint8"
-                    )
+                    print(f"converting boolean variable {var_name} to uint8")
                     ds[var_name] = ds[var_name].astype("uint8")
 
             # ensure each data variable has the CRS

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -254,7 +254,7 @@ def get_raster_value_at_point(
     y : float
         Northing or Latitude coordinate.
     target_crs : str
-        The expected CRS of the input coordinates (default NAD83(2011 / UTM zone 15N).
+        The expected CRS of the input coordinates (default NAD83(2011) / UTM zone 15N).
 
     Returns
     -------
@@ -689,7 +689,31 @@ def wpu_hsi_means(ds_hsi: xr.Dataset, wpu_grid: xr.DataArray) -> pd.DataFrame:
 
 def wpu_habitat_sums(ds_hab, zones, pulse_freq_metric=None):
     """
-    Calculates WPU-based sums for quality of fisheries habitat metrics.
+    Calculates WPU-based sums and area in km2 for quality
+    of fisheries habitat metrics.
+
+    Parameters
+    ------
+    ds_hab : xr.Dataset
+        The habitat dataset containing 'low_water_refuge' and 'flood_pulse'
+        variables. These are 3D arrays with dimensions (time, y, x).
+    zones : xr.DataArray
+        A 2D array with dimensions (y, x) representing zone identifiers
+        (e.g., Watershed Planning Units (WPU zones)). Must match the
+        spatial dimensions of ds_hab.
+    pulse_freq_metric : list of dict, optional
+        List containing dictionaries for each timestep with keys:
+        - 'timestep' : datetime
+        - 'flood_pulse_frequency' : int
+        Used to merge gage pulse frequency data into the spatial area results.
+
+    Returns
+    ------
+    pd.DataFrame
+        A DataFrame of annual timestep-WPU timeseries containing WPU IDs, timestamps,
+        pixel counts ('low_water_refuge', 'flood_pulse'),
+        calculated area in km2 ('low_water_refuge_km2', 'flood_pulse_km2'),
+        and annual gage pulse frequency ('flood_pulse_frequency').
     """
 
     zonal_ids = zones.squeeze(drop=True)

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -683,6 +683,40 @@ def wpu_hsi_means(ds_hsi: xr.Dataset, wpu_grid: xr.DataArray) -> pd.DataFrame:
         .reset_index(drop=True)
     )
 
+def wpu_habitat_sums(ds_hab, zones, pulse_freq_metric=None):
+    """
+    Calculates WPU-based sums for quality of fisheries habitat metrics.
+    """
+    # Standardize the spatial alignment
+    ds_hab.rio.write_crs("EPSG:6344", inplace=True)
+    zones.rio.write_crs("EPSG:32615", inplace=True)
+    
+    zonal_ids = zones.rio.reproject_match(ds_hab).compute()
+    zonal_ids.name = "wpu"
+    
+    # Calculate pixel counts grouped by WPU
+    df = (
+        ds_hab.groupby(zonal_ids)
+        .sum()
+        .to_dataframe()
+        .reset_index()
+    )
+    
+    df.rename(columns={"time": "timestep"}, inplace=True)
+    
+    # Merge frequency metric
+    if pulse_freq_metric:
+        df_metric = pd.DataFrame(pulse_freq_metric)
+        df = df.merge(df_metric, on="timestep", how="left")
+        
+    # Convert pixel counts (60m) to Area (km2)
+    df["low_water_refuge_km2"] = df["low_water_refuge"] * 0.0036
+    df["flood_pulse_km2"] = df["flood_pulse"] * 0.0036
+    
+    cols_to_drop = ["spatial_ref"]
+    df = df.drop(columns=[c for c in cols_to_drop if c in df.columns])
+    
+    return df.sort_values(["timestep", "wpu"])
 
 def generate_filename(
     params: dict,

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -237,7 +237,7 @@ def load_mf_tifs(
 
 
 def get_raster_value_at_point(
-    raster_path: str, x: float, y: float, target_crs: str = "EPSG:26915"
+    raster_path: str, x: float, y: float, target_crs: str = "EPSG:6344"
 ) -> float:
     """
     Extracts a single numeric value from a raster at a specific coordinate.
@@ -254,7 +254,7 @@ def get_raster_value_at_point(
     y : float
         Northing or Latitude coordinate.
     target_crs : str
-        The expected CRS of the input coordinates (default UTM Zone 15N).
+        The expected CRS of the input coordinates (default NAD83(2011 / UTM zone 15N).
 
     Returns
     -------

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -687,11 +687,8 @@ def wpu_habitat_sums(ds_hab, zones, pulse_freq_metric=None):
     """
     Calculates WPU-based sums for quality of fisheries habitat metrics.
     """
-    # Standardize the spatial alignment
-    ds_hab.rio.write_crs("EPSG:6344", inplace=True)
-    zones.rio.write_crs("EPSG:32615", inplace=True)
     
-    zonal_ids = zones.rio.reproject_match(ds_hab).compute()
+    zonal_ids = zones.squeeze(drop=True)
     zonal_ids.name = "wpu"
     
     # Calculate pixel counts grouped by WPU

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -125,7 +125,10 @@ def extract_date(path: pathlib.Path) -> datetime:
         date_str = path.stem.split("_")[-3:]  # Extract the last three
         date_str = "_".join(date_str)  # Combine back into "YYYY_MM_DD"
         return datetime.strptime(date_str, "%Y_%m_%d")
-    except (ValueError, IndexError):
+    except (
+        ValueError,
+        IndexError,
+    ):
         return None
 
 
@@ -683,37 +686,34 @@ def wpu_hsi_means(ds_hsi: xr.Dataset, wpu_grid: xr.DataArray) -> pd.DataFrame:
         .reset_index(drop=True)
     )
 
+
 def wpu_habitat_sums(ds_hab, zones, pulse_freq_metric=None):
     """
     Calculates WPU-based sums for quality of fisheries habitat metrics.
     """
-    
+
     zonal_ids = zones.squeeze(drop=True)
     zonal_ids.name = "wpu"
-    
+
     # Calculate pixel counts grouped by WPU
-    df = (
-        ds_hab.groupby(zonal_ids)
-        .sum()
-        .to_dataframe()
-        .reset_index()
-    )
-    
+    df = ds_hab.groupby(zonal_ids).sum().to_dataframe().reset_index()
+
     df.rename(columns={"time": "timestep"}, inplace=True)
-    
+
     # Merge frequency metric
     if pulse_freq_metric:
         df_metric = pd.DataFrame(pulse_freq_metric)
         df = df.merge(df_metric, on="timestep", how="left")
-        
+
     # Convert pixel counts (60m) to Area (km2)
     df["low_water_refuge_km2"] = df["low_water_refuge"] * 0.0036
     df["flood_pulse_km2"] = df["flood_pulse"] * 0.0036
-    
+
     cols_to_drop = ["spatial_ref"]
     df = df.drop(columns=[c for c in cols_to_drop if c in df.columns])
-    
+
     return df.sort_values(["timestep", "wpu"])
+
 
 def generate_filename(
     params: dict,
@@ -1137,13 +1137,13 @@ def analog_years_handler(
     # (e.g., velocity which is already a temporal average)
     if ds.sizes["time"] == 1:
         # Single timestep, just update the timestamp to match water year
-        target_date = pd.Timestamp(f"{water_year-1}-10-01")
+        target_date = pd.Timestamp(f"{water_year - 1}-10-01")
         ds = ds.assign_coords(time=("time", [target_date]))
         return ds
 
     # build a 365-day date range by dropping Feb 29
     target_range = pd.date_range(
-        f"{water_year-1}-10-01", f"{water_year}-09-30"
+        f"{water_year - 1}-10-01", f"{water_year}-09-30"
     )
     target_range = target_range[
         ~((target_range.month == 2) & (target_range.day == 29))
@@ -1278,7 +1278,7 @@ def create_binary_max_domain(
         start_idx = i * time_chunks
         end_idx = min((i + 1) * time_chunks, total_timesteps)
 
-        print(f"Processing timesteps {start_idx} to {end_idx-1}...")
+        print(f"Processing timesteps {start_idx} to {end_idx - 1}...")
 
         # Load only this chunk into memory
         if "time" in data.dims:
@@ -1529,9 +1529,9 @@ def process_netcdf_folder(
     print(f"Found {len(nc_files)} NetCDF files to process")
 
     for nc_file in nc_files:
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"Processing: {nc_file.name}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         try:
             ds = xr.open_dataset(nc_file)
@@ -1587,6 +1587,6 @@ def process_netcdf_folder(
             print(f"Error processing {nc_file.name}: {str(e)}")
             continue
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Batch processing complete!")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -1251,6 +1251,7 @@ class VegTransition:
                 "maturity",
                 "salinity_annual_mean",
                 "flood_pulse",
+                "low_water_refuge",
             ]
 
         with xr.open_dataset(self.netcdf_filepath, cache=False) as ds:
@@ -1359,20 +1360,42 @@ class VegTransition:
         )
         df.to_csv(veg_outpath)
 
+        # -------- WPU Habitat Metric CSV Summaries --------
         logging.info("Calculating WPU habitat metrics sums.")
-        df_lwr_fp = utils.wpu_sums(
-            ds_veg=ds[["flood_pulse", "low_water_refuge"]], zones=wpu
+
+        # Standardize the spatial alignment
+        ds.rio.write_crs("EPSG:6344", inplace=True)
+        wpu.rio.write_crs("EPSG:32615", inplace=True)
+
+        zonal_ids = wpu.rio.reproject_match(ds).compute()
+        zonal_ids.name = "wpu"
+        habitat_summary = (
+            ds[["low_water_refuge", "flood_pulse"]]
+            .groupby(zonal_ids)
+            .sum()
+            .to_dataframe()
+            .reset_index()
         )
 
-        # Apply the 0.0036 conversion factor to get km2
-        for col in ["flood_pulse", "low_water_refuge"]:
-            df_lwr_fp[f"{col}_km2"] = df_lwr_fp[col] * 0.0036
+        df_habitat = habitat_summary.copy()
+        df_habitat.rename(columns={"time": "timestep"}, inplace=True)
 
-        lwr_fp_outpath = os.path.join(
+        # Convert pixel counts to km2
+        df_habitat["low_water_refuge_km2"] = (
+            df_habitat["low_water_refuge"] * 0.0036
+        )
+        df_habitat["flood_pulse_km2"] = df_habitat["flood_pulse"] * 0.0036
+
+        cols_to_drop = ["spatial_ref"]
+        df_habitat = df_habitat.drop(
+            columns=[c for c in cols_to_drop if c in df_habitat.columns]
+        )
+
+        hab_outpath = os.path.join(
             self.run_metadata_dir,
             f"{self.file_name}_wpu_habitat_timeseries.csv",
         )
-        df_lwr_fp.to_csv(lwr_fp_outpath)
+        df_habitat.to_csv(hab_outpath, index=False)
 
         logging.info("Calculating full-domain veg type sums.")
         df_full_domain = utils.pixel_sums_full_domain(
@@ -1416,6 +1439,8 @@ class VegTransition:
         """
         self._logger.info("Calculating Flood Pulse Inundation.")
 
+        arr = np.where(self.hydro_domain, 0.0, np.nan).astype(np.float32)
+
         # Define the gage coordinates (Butte LaRose Gage)
         blr_x, blr_y = 626304.02, 3350717.43
 
@@ -1437,36 +1462,39 @@ class VegTransition:
                 f"Flood Pulse Criteria Met: {self.blr_flooding_days} days."
             )
 
-            # Select Dec-May window for the entire domain grid
+            # Select Dec-May window
             dm_depth = self.water_depth.sel(
                 time=self.water_depth.time.dt.month.isin([12, 1, 2, 3, 4, 5])
             )["height"]
 
-            # Binary map: Pixel was flooded > 5cm on ANY day in window AND is not Open Water (26)
             is_flooded = (dm_depth > depth_thresh).any(dim="time")
 
-            return (
-                (is_flooded & (self.veg_type != 26)).astype(np.int8).to_numpy()
+            # Binary map: Pixel was flooded > 5cm on ANY day in window AND is not Open Water (26)
+            flood_pulse_calc = (is_flooded & (self.veg_type != 26)).astype(
+                np.float32
+            )
+            arr = np.where(self.hydro_domain, flood_pulse_calc, np.nan)
+
+        else:
+            self._logger.info(
+                f"Flood Pulse Criteria not Met: {self.blr_flooding_days} days."
             )
 
-        self._logger.info(
-            f"Flood Pulse Criteria not Met: {self.blr_flooding_days} days."
+        return arr
+
+    def calculate_low_water_refuge(self, depth_thresh=1.0, persistence=0.9):
+        # Calculate persistence
+        persistence_map = (self.water_depth.height >= depth_thresh).mean(
+            dim="time"
         )
-        return np.zeros_like(self.veg_type, dtype=np.int8)
 
-    def calculate_low_water_refuge(
-        self, depth_thresh: float = 1.0, persistence: float = 0.9
-    ) -> np.ndarray:
-        """
-        LWR Logic: Depth >= 1.0m for 90% of the October-January window.
-        Returns binary map (1=refuge, 0=not).
-        """
-        ds_window = self.water_depth.sel(
-            time=self.water_depth.time.dt.month.isin([10, 11, 12, 1])
-        )["height"]
-        lwr_da = (ds_window >= depth_thresh).mean(dim="time") >= persistence
+        # Create Binary Mask (1.0 for True, 0.0 for False)
+        lwr_binary = xr.where(persistence_map >= persistence, 1.0, 0.0).astype(
+            np.float32
+        )
 
-        return lwr_da.astype(np.int8).to_numpy()
+        # Apply domain mask
+        return lwr_binary.where(self.hydro_domain)
 
     def create_qc_arrays(self):
         """

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -190,6 +190,7 @@ class VegTransition:
 
         self.flood_pulse = None
         self.blr_flooding_days = 0
+        self.low_water_refuge = None
 
         # initialize partial update arrays as None
         # self.veg_type_update_1 = None
@@ -421,6 +422,7 @@ class VegTransition:
         self.water_depth = None
 
         self.flood_pulse = self.calculate_flood_pulse()
+        self.low_water_refuge = self.calculate_low_water_refuge()
 
         # clean up mpl objects
         plt.cla()
@@ -1433,6 +1435,20 @@ class VegTransition:
             f"Flood Pulse Criteria not Met: {self.blr_flooding_days} days."
         )
         return np.zeros_like(self.veg_type, dtype=np.int8)
+
+    def calculate_low_water_refuge(
+        self, depth_thresh: float = 1.0, persistence: float = 0.9
+    ) -> np.ndarray:
+        """
+        LWR Logic: Depth >= 1.0m for 90% of the October-January window.
+        Returns binary map (1=refuge, 0=not).
+        """
+        ds_window = self.water_depth.sel(
+            time=self.water_depth.time.dt.month.isin([10, 11, 12, 1])
+        )["height"]
+        lwr_da = (ds_window >= depth_thresh).mean(dim="time") >= persistence
+
+        return lwr_da.astype(np.int8).to_numpy()
 
     def create_qc_arrays(self):
         """

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -417,6 +417,13 @@ class VegTransition:
 
         self._calculate_maturity(veg_type_in)
 
+        self.flooded = (
+            (self.water_depth["height"] > 0.05)
+            .max(dim="time")
+            .where(self.hydro_domain, np.nan)
+            .astype(np.float32)
+        )
+
         # serialize state variables: veg_type, maturity, mast %
         self._logger.info("saving state variables for timestep.")
         self._append_veg_vars_to_netcdf(timestep=self.current_timestep)
@@ -1250,6 +1257,7 @@ class VegTransition:
                 "veg_type",
                 "maturity",
                 "salinity_annual_mean",
+                "flooded",
                 "flood_pulse",
                 "low_water_refuge",
             ]

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -184,6 +184,13 @@ class VegTransition:
         self.veg_ts_out = None  # xarray output for timestep
         self.salinity_annual_mean = None
 
+        self.dem_at_blr = utils.get_raster_value_at_point(
+            self.dem_path, 626304.02, 3350717.43
+        )
+
+        self.flood_pulse = None
+        self.blr_flooding_days = 0
+
         # initialize partial update arrays as None
         # self.veg_type_update_1 = None
         # self.veg_type_update_2 = None
@@ -413,6 +420,8 @@ class VegTransition:
         self.current_timestep = None
         self.water_depth = None
 
+        self.flood_pulse = self.calculate_flood_pulse()
+
         # clean up mpl objects
         plt.cla()
         plt.clf()
@@ -533,7 +542,11 @@ class VegTransition:
         # and the truncating for this purpose.
         analog_year = int(f"20{analog_year_str}")
 
-        model = "XGB" if hydro_variable == "DO" else self.file_params['hydro_source_model']
+        model = (
+            "XGB"
+            if hydro_variable == "DO"
+            else self.file_params["hydro_source_model"]
+        )
         nc_path = os.path.join(
             variable_base_path,
             f"AMP_{model}_WY{analog_year_str}_"
@@ -1007,9 +1020,7 @@ class VegTransition:
                 salinity["salinity"].mean(dim="time").compute().to_numpy()
             )
             salinity.close()
-            del (
-                salinity
-            )  # del the dataset because this is the only salinity var
+            del salinity  # del the dataset because this is the only salinity var
 
         else:
             # if salinity is a numpy array, it is the veg-based
@@ -1236,6 +1247,7 @@ class VegTransition:
                 "veg_type",
                 "maturity",
                 "salinity_annual_mean",
+                "flood_pulse",
             ]
 
         with xr.open_dataset(self.netcdf_filepath, cache=False) as ds:
@@ -1374,6 +1386,53 @@ class VegTransition:
         )
 
         logging.info("Post-processing complete.")
+
+    def calculate_flood_pulse(
+        self, stage_thresh: float = 3.6, depth_thresh: float = 0.05
+    ) -> np.ndarray:
+        """
+        Flood Pulse Metric: Dec-May window.
+        Triggered by BLR Gage Stage (WSE) > 3.6m for 121-157 days.
+        """
+        self._logger.info("Calculating Flood Pulse Inundation.")
+
+        # Define the gage coordinates (Butte LaRose Gage)
+        blr_x, blr_y = 626304.02, 3350717.43
+
+        # Extract depth series at gage for Dec-May
+        blr_depth = (
+            self.water_depth["height"]
+            .sel(x=blr_x, y=blr_y, method="nearest")
+            .sel(time=self.water_depth.time.dt.month.isin([12, 1, 2, 3, 4, 5]))
+        )
+
+        # Reconstruct Stage (WSE = Depth + self.dem_at_blr)
+        self.blr_flooding_days = (
+            ((blr_depth + self.dem_at_blr) > stage_thresh).sum().values
+        )
+
+        # Map spatial extent only if the gage trigger is satisfied
+        if 121 <= self.blr_flooding_days <= 157:
+            self._logger.info(
+                f"Flood Pulse Criteria Met: {self.blr_flooding_days} days."
+            )
+
+            # Select Dec-May window for the entire domain grid
+            dm_depth = self.water_depth.sel(
+                time=self.water_depth.time.dt.month.isin([12, 1, 2, 3, 4, 5])
+            )["height"]
+
+            # Binary map: Pixel was flooded > 5cm on ANY day in window AND is not Open Water (26)
+            is_flooded = (dm_depth > depth_thresh).any(dim="time")
+
+            return (
+                (is_flooded & (self.veg_type != 26)).astype(np.int8).to_numpy()
+            )
+
+        self._logger.info(
+            f"Flood Pulse Criteria not Met: {self.blr_flooding_days} days."
+        )
+        return np.zeros_like(self.veg_type, dtype=np.int8)
 
     def create_qc_arrays(self):
         """

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -304,6 +304,10 @@ class VegTransition:
         veg_type_in = self.veg_type.copy()
         self.water_depth = self._load_depth_general(self.wy)
 
+        # habitat metrics
+        self.flood_pulse = self.calculate_flood_pulse()
+        self.low_water_refuge = self.calculate_low_water_refuge()
+
         self._get_annual_avg_salinity()
         self.create_qc_arrays()
 
@@ -420,9 +424,6 @@ class VegTransition:
         self._logger.info("completed timestep: %s", timestep)
         self.current_timestep = None
         self.water_depth = None
-
-        self.flood_pulse = self.calculate_flood_pulse()
-        self.low_water_refuge = self.calculate_low_water_refuge()
 
         # clean up mpl objects
         plt.cla()
@@ -1351,15 +1352,32 @@ class VegTransition:
 
         logging.info("Calculating WPU veg type sums.")
         ds = xr.open_dataset(self.netcdf_filepath)
-        df = utils.wpu_sums(ds_veg=ds, zones=wpu)
-        outpath = os.path.join(
+        df = utils.wpu_sums(ds_veg=ds[["veg_type", "maturity"]], zones=wpu)
+        veg_outpath = os.path.join(
             self.run_metadata_dir,
             f"{self.file_name}_wpu_vegtype_timeseries.csv",
         )
-        df.to_csv(outpath)
+        df.to_csv(veg_outpath)
+
+        logging.info("Calculating WPU habitat metrics sums.")
+        df_lwr_fp = utils.wpu_sums(
+            ds_veg=ds[["flood_pulse", "low_water_refuge"]], zones=wpu
+        )
+
+        # Apply the 0.0036 conversion factor to get km2
+        for col in ["flood_pulse", "low_water_refuge"]:
+            df_lwr_fp[f"{col}_km2"] = df_lwr_fp[col] * 0.0036
+
+        lwr_fp_outpath = os.path.join(
+            self.run_metadata_dir,
+            f"{self.file_name}_wpu_habitat_timeseries.csv",
+        )
+        df_lwr_fp.to_csv(lwr_fp_outpath)
 
         logging.info("Calculating full-domain veg type sums.")
-        df_full_domain = utils.pixel_sums_full_domain(ds=ds)
+        df_full_domain = utils.pixel_sums_full_domain(
+            ds=ds[["veg_type", "maturity"]]
+        )
         outpath = os.path.join(
             self.run_metadata_dir, f"{self.file_name}_vegtype_timeseries.csv"
         )

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -1462,7 +1462,7 @@ class VegTransition:
             # Binary map: Pixel was flooded > 5cm on ANY day in window AND is not Open Water (26)
             pulse_extent = is_flooded.where((self.veg_type != 26), 0.0)
             pulse_extent = pulse_extent.where(
-                self.hydro_domain.notnull(), np.nan
+                ~np.isnan(self.hydro_domain), np.nan
             ).to_numpy()
 
         else:

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -1030,7 +1030,9 @@ class VegTransition:
                 salinity["salinity"].mean(dim="time").compute().to_numpy()
             )
             salinity.close()
-            del salinity  # del the dataset because this is the only salinity var
+            del (
+                salinity
+            )  # del the dataset because this is the only salinity var
 
         else:
             # if salinity is a numpy array, it is the veg-based

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -1492,7 +1492,9 @@ class VegTransition:
             self._logger.info(
                 f"Flood Pulse Criteria not Met: {self.flood_pulse_freq} days."
             )
-            pulse_extent = xr.where(self.hydro_domain, 0.0, np.nan)
+            pulse_extent = (self.hydro_domain * 0.0).where(
+                self.hydro_domain, np.nan
+            )
 
         return pulse_extent.to_numpy().astype(np.float32)
 

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -189,7 +189,8 @@ class VegTransition:
         )
 
         self.flood_pulse = None
-        self.blr_flooding_days = 0
+        self.flood_pulse_freq = 0
+        self.pulse_freq_metric = []
         self.low_water_refuge = None
 
         # initialize partial update arrays as None
@@ -304,9 +305,15 @@ class VegTransition:
         veg_type_in = self.veg_type.copy()
         self.water_depth = self._load_depth_general(self.wy)
 
-        # habitat metrics
+        # quality of fisheries habitat metrics
         self.flood_pulse = self.calculate_flood_pulse()
         self.low_water_refuge = self.calculate_low_water_refuge()
+        self.pulse_freq_metric.append(
+            {
+                "timestep": timestep,
+                "flood_pulse_frequency": float(self.flood_pulse_freq),
+            }
+        )
 
         self._get_annual_avg_salinity()
         self.create_qc_arrays()
@@ -416,13 +423,6 @@ class VegTransition:
             )
 
         self._calculate_maturity(veg_type_in)
-
-        self.flooded = (
-            (self.water_depth["height"] > 0.05)
-            .max(dim="time")
-            .where(self.hydro_domain, np.nan)
-            .astype(np.float32)
-        )
 
         # serialize state variables: veg_type, maturity, mast %
         self._logger.info("saving state variables for timestep.")
@@ -1257,7 +1257,6 @@ class VegTransition:
                 "veg_type",
                 "maturity",
                 "salinity_annual_mean",
-                "flooded",
                 "flood_pulse",
                 "low_water_refuge",
             ]
@@ -1368,7 +1367,7 @@ class VegTransition:
         )
         df.to_csv(veg_outpath)
 
-        # -------- WPU Habitat Metric CSV Summaries --------
+        # -------- WPU Quality of Fisheries Habitat Metric CSV Summaries --------
         logging.info("Calculating WPU habitat metrics sums.")
 
         # Standardize the spatial alignment
@@ -1387,6 +1386,9 @@ class VegTransition:
 
         df_habitat = habitat_summary.copy()
         df_habitat.rename(columns={"time": "timestep"}, inplace=True)
+        if self.pulse_freq_metric:
+            df_metric = pd.DataFrame(self.pulse_freq_metric)
+            df_habitat = df_habitat.merge(df_metric, on="timestep", how="left")
 
         # Convert pixel counts to km2
         df_habitat["low_water_refuge_km2"] = (
@@ -1438,71 +1440,84 @@ class VegTransition:
 
         logging.info("Post-processing complete.")
 
+    # --- Quality of Fisheries Habitat Metrics ---
+
     def calculate_flood_pulse(
         self, stage_thresh: float = 3.6, depth_thresh: float = 0.05
     ) -> np.ndarray:
         """
         Flood Pulse Metric: Dec-May window.
-        Triggered by BLR Gage Stage (WSE) > 3.6m for 121-157 days.
+        Extent is generated only if BLR Gage Stage (WSE) > 3.6m for 121-157 days.
         """
         self._logger.info("Calculating Flood Pulse Inundation.")
 
-        arr = np.where(self.hydro_domain, 0.0, np.nan).astype(np.float32)
-
-        # Define the gage coordinates (Butte LaRose Gage)
-        blr_x, blr_y = 626304.02, 3350717.43
+        # Define the Butte LaRose (BLR) gage coordinates and analysis months
+        blr_gage_x, blr_gage_y = 626304.02, 3350717.43
+        pulse_months = [12, 1, 2, 3, 4, 5]
 
         # Extract depth series at gage for Dec-May
         blr_depth = (
             self.water_depth["height"]
-            .sel(x=blr_x, y=blr_y, method="nearest")
-            .sel(time=self.water_depth.time.dt.month.isin([12, 1, 2, 3, 4, 5]))
+            .sel(x=blr_gage_x, y=blr_gage_y, method="nearest")
+            .sel(time=self.water_depth.time.dt.month.isin(pulse_months))
         )
 
+        # Calculate Flood Pulse Frequency
         # Reconstruct Stage (WSE = Depth + self.dem_at_blr)
-        self.blr_flooding_days = (
-            ((blr_depth + self.dem_at_blr) > stage_thresh).sum().values
-        )
+        self.flood_pulse_freq = (
+            (blr_depth + self.dem_at_blr) > stage_thresh
+        ).sum()
 
-        # Map spatial extent only if the gage trigger is satisfied
-        if 121 <= self.blr_flooding_days <= 157:
+        # Map flood pulse extent only if the gage trigger is satisfied
+        if 121 <= self.flood_pulse_freq <= 157:
             self._logger.info(
-                f"Flood Pulse Criteria Met: {self.blr_flooding_days} days."
+                f"Flood Pulse Criteria Met: {self.flood_pulse_freq} days."
             )
 
-            # Select Dec-May window
-            dm_depth = self.water_depth.sel(
-                time=self.water_depth.time.dt.month.isin([12, 1, 2, 3, 4, 5])
-            )["height"]
+            # Filter data by Dec-May months
+            filtered = self.water_depth.sel(
+                time=self.water_depth.time.dt.month.isin(pulse_months)
+            )
 
-            is_flooded = (dm_depth > depth_thresh).any(dim="time")
+            # Flooded > 5cm on any day from Dec - May
+            is_flooded = (filtered["height"] > depth_thresh).any(dim="time")
 
             # Binary map: Pixel was flooded > 5cm on ANY day in window AND is not Open Water (26)
-            flood_pulse_calc = (is_flooded & (self.veg_type != 26)).astype(
-                np.float32
+            pulse_extent = xr.where(
+                is_flooded & (self.veg_type != 26), 1.0, 0.0
             )
-            arr = np.where(self.hydro_domain, flood_pulse_calc, np.nan)
+            pulse_extent = pulse_extent.where(self.hydro_domain, np.nan)
 
         else:
             self._logger.info(
-                f"Flood Pulse Criteria not Met: {self.blr_flooding_days} days."
+                f"Flood Pulse Criteria not Met: {self.flood_pulse_freq} days."
             )
+            pulse_extent = xr.where(self.hydro_domain, 0.0, np.nan)
 
-        return arr
+        return pulse_extent.to_numpy().astype(np.float32)
 
     def calculate_low_water_refuge(self, depth_thresh=1.0, persistence=0.9):
+        """
+        Determines which 60m grid cells are flooded with at least 1m
+        of water between October 1 and January 31. Areas which meet this criteria
+        for 90% of the days are designated as areas of potential low water refuge.
+        """
+        self._logger.info("Calculating Low Water Refuge (Oct - Jan).")
+
+        winter_depth = self.water_depth.sel(
+            time=self.water_depth.time.dt.month.isin([10, 11, 12, 1])
+        )
+
         # Calculate persistence
-        persistence_map = (self.water_depth.height >= depth_thresh).mean(
+        persistence_map = (winter_depth.height >= depth_thresh).mean(
             dim="time"
         )
 
         # Create Binary Mask (1.0 for True, 0.0 for False)
-        lwr_binary = xr.where(persistence_map >= persistence, 1.0, 0.0).astype(
-            np.float32
-        )
+        lwr_extent = xr.where(persistence_map >= persistence, 1.0, 0.0)
+        lwr_extent = lwr_extent.where(self.hydro_domain, np.nan)
 
-        # Apply domain mask
-        return lwr_binary.where(self.hydro_domain)
+        return lwr_extent.to_numpy().astype(np.float32)
 
     def create_qc_arrays(self):
         """

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -1370,35 +1370,10 @@ class VegTransition:
         # -------- WPU Quality of Fisheries Habitat Metric CSV Summaries --------
         logging.info("Calculating WPU habitat metrics sums.")
 
-        # Standardize the spatial alignment
-        ds.rio.write_crs("EPSG:6344", inplace=True)
-        wpu.rio.write_crs("EPSG:32615", inplace=True)
-
-        zonal_ids = wpu.rio.reproject_match(ds).compute()
-        zonal_ids.name = "wpu"
-        habitat_summary = (
-            ds[["low_water_refuge", "flood_pulse"]]
-            .groupby(zonal_ids)
-            .sum()
-            .to_dataframe()
-            .reset_index()
-        )
-
-        df_habitat = habitat_summary.copy()
-        df_habitat.rename(columns={"time": "timestep"}, inplace=True)
-        if self.pulse_freq_metric:
-            df_metric = pd.DataFrame(self.pulse_freq_metric)
-            df_habitat = df_habitat.merge(df_metric, on="timestep", how="left")
-
-        # Convert pixel counts to km2
-        df_habitat["low_water_refuge_km2"] = (
-            df_habitat["low_water_refuge"] * 0.0036
-        )
-        df_habitat["flood_pulse_km2"] = df_habitat["flood_pulse"] * 0.0036
-
-        cols_to_drop = ["spatial_ref"]
-        df_habitat = df_habitat.drop(
-            columns=[c for c in cols_to_drop if c in df_habitat.columns]
+        df_habitat = utils.wpu_habitat_sums(
+            ds_hab=ds[["low_water_refuge", "flood_pulse"]],
+            zones=wpu,
+            pulse_freq_metric=self.pulse_freq_metric,
         )
 
         hab_outpath = os.path.join(
@@ -1406,6 +1381,8 @@ class VegTransition:
             f"{self.file_name}_wpu_habitat_timeseries.csv",
         )
         df_habitat.to_csv(hab_outpath, index=False)
+
+        # -------- Full Domain Vegetation Type CSV Summaries --------
 
         logging.info("Calculating full-domain veg type sums.")
         df_full_domain = utils.pixel_sums_full_domain(
@@ -1483,20 +1460,18 @@ class VegTransition:
             is_flooded = (filtered["height"] > depth_thresh).any(dim="time")
 
             # Binary map: Pixel was flooded > 5cm on ANY day in window AND is not Open Water (26)
-            pulse_extent = xr.where(
-                is_flooded & (self.veg_type != 26), 1.0, 0.0
-            )
-            pulse_extent = pulse_extent.where(self.hydro_domain, np.nan)
+            pulse_extent = is_flooded.where((self.veg_type != 26), 0.0)
+            pulse_extent = pulse_extent.where(
+                self.hydro_domain.notnull(), np.nan
+            ).to_numpy()
 
         else:
             self._logger.info(
                 f"Flood Pulse Criteria not Met: {self.flood_pulse_freq} days."
             )
-            pulse_extent = (self.hydro_domain * 0.0).where(
-                self.hydro_domain, np.nan
-            )
+            pulse_extent = np.where(np.isnan(self.hydro_domain), np.nan, 0.0)
 
-        return pulse_extent.to_numpy().astype(np.float32)
+        return pulse_extent.astype(np.float32)
 
     def calculate_low_water_refuge(self, depth_thresh=1.0, persistence=0.9):
         """

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -1432,18 +1432,31 @@ class VegTransition:
         blr_gage_x, blr_gage_y = 626304.02, 3350717.43
         pulse_months = [12, 1, 2, 3, 4, 5]
 
-        # Extract depth series at gage for Dec-May
-        blr_depth = (
-            self.water_depth["height"]
-            .sel(x=blr_gage_x, y=blr_gage_y, method="nearest")
-            .sel(time=self.water_depth.time.dt.month.isin(pulse_months))
+        # Depth from Dec-May
+        dec_may_pulse = self.water_depth["height"].sel(
+            time=self.water_depth.time.dt.month.isin(pulse_months)
+        )
+
+        # Extract gage depth at gage for Dec-May
+        blr_depth = dec_may_pulse.sel(
+            x=blr_gage_x,
+            y=blr_gage_y,
+            method="nearest",
         )
 
         # Calculate Flood Pulse Frequency
         # Reconstruct Stage (WSE = Depth + self.dem_at_blr)
         self.flood_pulse_freq = (
-            (blr_depth + self.dem_at_blr) > stage_thresh
-        ).sum()
+            ((blr_depth + self.dem_at_blr) > stage_thresh)
+            .sum()
+            .compute()
+            .item()
+        )
+
+        pulse_extent = np.full(
+            self.hydro_domain.shape, np.nan, dtype=np.float32
+        )
+        pulse_extent[self.hydro_domain] = 0.0
 
         # Map flood pulse extent only if the gage trigger is satisfied
         if 121 <= self.flood_pulse_freq <= 157:
@@ -1451,27 +1464,24 @@ class VegTransition:
                 f"Flood Pulse Criteria Met: {self.flood_pulse_freq} days."
             )
 
-            # Filter data by Dec-May months
-            filtered = self.water_depth.sel(
-                time=self.water_depth.time.dt.month.isin(pulse_months)
+            # Flooded > 5cm on any day from Dec - May
+            is_flooded = (
+                (dec_may_pulse > depth_thresh).any(dim="time").compute().values
             )
 
-            # Flooded > 5cm on any day from Dec - May
-            is_flooded = (filtered["height"] > depth_thresh).any(dim="time")
+            # Only include veg clasess we model (16-24)
+            habitat_mask = (self.veg_type >= 16) & (self.veg_type <= 24)
+            valid_mask = self.hydro_domain & habitat_mask
 
-            # Binary map: Pixel was flooded > 5cm on ANY day in window AND is not Open Water (26)
-            pulse_extent = is_flooded.where((self.veg_type != 26), 0.0)
-            pulse_extent = pulse_extent.where(
-                ~np.isnan(self.hydro_domain), np.nan
-            ).to_numpy()
+            # Flooded and not Open Water
+            pulse_extent[valid_mask & is_flooded] = 1.0
 
         else:
             self._logger.info(
                 f"Flood Pulse Criteria not Met: {self.flood_pulse_freq} days."
             )
-            pulse_extent = np.where(np.isnan(self.hydro_domain), np.nan, 0.0)
 
-        return pulse_extent.astype(np.float32)
+        return pulse_extent
 
     def calculate_low_water_refuge(self, depth_thresh=1.0, persistence=0.9):
         """


### PR DESCRIPTION
This PR solves #142 by adding flood pulse, and low water refuge extents to Veg NetCDF and creating CSV summaries of pixel count and area by WPU. Flood Pulse Frequency was also added to the CSV.

Guidance: 

**Flood Pulse Metric:**
The metric is calculated using two components: Flood Pulse Frequency and Flood Pulse Extent. Frequency was assessed using 60m gridded stage data from the H&H models focusing on the grid cell that includes the Butte LaRose gauge to identify which years exceed stage of 3.6m for 121-157 days per year.
Once the frequency condition is met, the extent component is used to assess the spatial extent of flooding. This involves identifying the grid cells within the basin that are inundated (water depth greater than 5cm) during the qualifying days and calculating the percentage of the basin area that experiences flooding for that specified duration between December 1 and May 31.
**Presently, in the Without Project runs, only MIKE WY20 exceeds that stage at BLR. But it is possible that projects could change that. And they can also influence which areas get flooded at that stage.**

**Low Water Refuge:**
The extent of Low Water Refuge uses daily H&H stage/depth outputs to determine which 60m grid cells are flooded with at least 1m of water between October 1 and January 31.  Areas which meet this criteria for 90% of the days between October 1 and January 31 are designated as areas of potential low water refuge.