### PR TITLE
habitat units summary to CSV outputs

### DIFF
--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -2194,6 +2194,7 @@ class HSI(vt.VegTransition):
         self._write_variable_sidecar_csv(resolution=60)
         self._write_sedflux_waterbody_means_csv()
         self._write_wpu_hsi_means_csv()
+        self._write_wpu_hsi_habitat_units_csv()
         self._convert_outputs_to_cogs()
         self._logger.info("HSI post-processing complete.")
 
@@ -2269,6 +2270,30 @@ class HSI(vt.VegTransition):
             self.run_metadata_dir, f"{self.file_name}_wpu_hsi_means.csv"
         )
         df_hsi_wpu.to_csv(outpath, index=False)
+
+    def _write_wpu_hsi_habitat_units_csv(self) -> None:
+        """Compute WPU-zone Habitat Units scores from the 480m output."""
+        self._logger.info("Calculating WPU Habitat Units.")
+        with xr.open_dataset(self.netcdf_filepath) as ds:
+            ds_hsi = ds.load()
+
+        if "year" in ds_hsi.dims:
+            ds_hsi = ds_hsi.rename({"year": "time"})
+
+        wpu_grid = (
+            xr.open_dataarray(self.wpu_grid_path, engine="rasterio")
+            .isel(band=0)
+            .load()
+        )
+
+        df_habitat_units = utils.wpu_habitat_units(
+            ds_hsi=ds_hsi, wpu_grid=wpu_grid
+        )
+        outpath = os.path.join(
+            self.run_metadata_dir,
+            f"{self.file_name}_wpu_hsi_habitat_units.csv",
+        )
+        df_habitat_units.to_csv(outpath, index=False)
 
     # SEDFLUX is a post-process-only access pattern: it is not consumed by any
     # HSI suitability model, only assembled here and written to the 60m output.
@@ -2435,7 +2460,9 @@ class HSI(vt.VegTransition):
         for i in range(mask.sizes["waterbody"]):
             m = mask.isel(waterbody=i)
             # spatial mean over this waterbody's pixels, one value per year
-            annual_mean = sedflux.where(m > 0).mean(dim=("y", "x"), skipna=True)
+            annual_mean = sedflux.where(m > 0).mean(
+                dim=("y", "x"), skipna=True
+            )
             for t, val in zip(
                 annual_mean["time"].to_numpy(), annual_mean.to_numpy()
             ):

--- a/VegProcessor/hsi.py
+++ b/VegProcessor/hsi.py
@@ -2261,9 +2261,7 @@ class HSI(vt.VegTransition):
         if "year" in ds_hsi.dims:
             ds_hsi = ds_hsi.rename({"year": "time"})
 
-        wpu_grid = xr.open_dataarray(
-            self.wpu_grid_path, engine="rasterio"
-        ).isel(band=0)
+        wpu_grid = self._load_wpu_grid()
 
         df_hsi_wpu = utils.wpu_hsi_means(ds_hsi=ds_hsi, wpu_grid=wpu_grid)
         outpath = os.path.join(
@@ -2280,11 +2278,7 @@ class HSI(vt.VegTransition):
         if "year" in ds_hsi.dims:
             ds_hsi = ds_hsi.rename({"year": "time"})
 
-        wpu_grid = (
-            xr.open_dataarray(self.wpu_grid_path, engine="rasterio")
-            .isel(band=0)
-            .load()
-        )
+        wpu_grid = self._load_wpu_grid().load()
 
         df_habitat_units = utils.wpu_habitat_units(
             ds_hsi=ds_hsi, wpu_grid=wpu_grid

--- a/VegProcessor/utils.py
+++ b/VegProcessor/utils.py
@@ -687,6 +687,92 @@ def wpu_hsi_means(ds_hsi: xr.Dataset, wpu_grid: xr.DataArray) -> pd.DataFrame:
     )
 
 
+def wpu_habitat_units(
+    ds_hsi: xr.Dataset, wpu_grid: xr.DataArray
+) -> pd.DataFrame:
+    """Computes annual HSI/SI mean scores and Habitat Units (HU) in km2 grouped by WPU.
+
+    A habitat unit represents the total ecological value of an area, calculated by
+    multiplying the mean suitability index (HSI/SI) by the active, non-NaN spatial area
+    utilized to determine that specific HSI/SI score.
+    """
+
+    hsi_vars = [
+        var
+        for var in ds_hsi.data_vars
+        if "_hsi" in var.lower() or "_si_" in var.lower()
+    ]
+
+    if not hsi_vars:
+        return pd.DataFrame()
+
+    # Downsamples the 60m WPU grid to the 480m HSI grid
+    zonal_ids = wpu_grid.rio.reproject_match(ds_hsi).compute()
+    zonal_ids.name = "wpu"
+
+    # Mask out non-WPU areas
+    zonal_ids = xr.where(zonal_ids > 0, zonal_ids, np.nan)
+
+    # Calculate pixel area from pixel resolution (480 x 480) and convert from m2 to km2
+    res_x, res_y = ds_hsi.rio.resolution()
+    pixel_area_km2 = abs(res_x * res_y) / 1_000_000
+
+    # Group by WPU and calculate both means and valid pixel counts
+    grouped = ds_hsi[hsi_vars].groupby(zonal_ids)
+    ds_zonal_means = grouped.mean()
+    ds_zonal_counts = grouped.count()  # Counts non-NaN pixels per WPU
+
+    df_means = ds_zonal_means.to_dataframe().reset_index()
+    df_counts = ds_zonal_counts.to_dataframe().reset_index()
+
+    if "time" in df_means.columns:
+        df_means.rename(columns={"time": "timestep"}, inplace=True)
+        df_counts.rename(columns={"time": "timestep"}, inplace=True)
+
+    df_means = df_means.dropna(subset=["wpu"])
+    df_means["wpu"] = df_means["wpu"].astype(int)
+
+    df_counts = df_counts.dropna(subset=["wpu"])
+    df_counts["wpu"] = df_counts["wpu"].astype(int)
+
+    # Merge means and counts
+    merge_cols = (
+        ["timestep", "wpu"] if "timestep" in df_means.columns else ["wpu"]
+    )
+    df_merged = pd.merge(
+        df_means, df_counts, on=merge_cols, suffixes=("", "_count")
+    )
+
+    df_merged = df_merged.copy()
+
+    new_hu_columns = {}
+    for var in hsi_vars:
+        area_col = f"{var}_area_km2"
+        hu_col = f"{var}_hu"
+
+        mean_suitability = df_merged[var]
+
+        # Calculate HSI/SI area dynamically using its non-NaN pixel count
+        new_hu_columns[area_col] = df_merged[f"{var}_count"] * pixel_area_km2
+        # [HU Results] = [Mean HSI/SI Score] * [Area km2]
+        new_hu_columns[hu_col] = mean_suitability * new_hu_columns[area_col]
+
+    df_new_calcs = pd.DataFrame(new_hu_columns, index=df_merged.index)
+    df_final = pd.concat([df_merged, df_new_calcs], axis=1)
+
+    # Clean up the temporary count columns
+    drop_cols = [f"{var}_count" for var in hsi_vars]
+    df_final = df_final.drop(columns=drop_cols)
+
+    base_cols = (
+        ["timestep", "wpu"] if "timestep" in df_final.columns else ["wpu"]
+    )
+    calc_cols = [c for c in df_final.columns if c not in base_cols]
+    final_cols = base_cols + sorted(calc_cols)
+
+    return df_final[final_cols].sort_values(base_cols).reset_index(drop=True)
+
+
 def wpu_habitat_sums(ds_hab, zones, pulse_freq_metric=None):
     """
     Calculates WPU-based sums and area in km2 for quality

--- a/VegProcessor/veg_transition.py
+++ b/VegProcessor/veg_transition.py
@@ -987,6 +987,17 @@ class VegTransition:
         self._logger.info("Loaded Vegetation Keys")
         return dbf
 
+    def _load_wpu_grid(self) -> xr.DataArray:
+        """Load the WPU (Water Planning Unit) zone grid as a single-band DataArray.
+
+        Shared loader for the WPU zonal-ID raster (``wpu_grid_path``), used by
+        the post-processing summaries in both VegTransition and HSI. Opens the
+        raster, drops the singleton band dim, and masks the zone-0 sentinel
+        (pixels outside all WPU polygons) to NaN.
+        """
+        wpu = xr.open_dataarray(self.wpu_grid_path, engine="rasterio").isel(band=0)
+        return xr.where(wpu != 0, wpu, np.nan)
+
     def _load_initial_maturity_raster(self) -> np.ndarray:
         """Load initial conditions for vegetation maturity."""
         self._logger.info("Loading initial maturity raster.")
@@ -1376,10 +1387,7 @@ class VegTransition:
             exection time.
         """
         logging.info("Running post-processing routine.")
-        wpu = xr.open_dataarray(self.wpu_grid_path, engine="rasterio")
-        wpu = wpu.isel(band=0)
-        # Replace 0 with NaN (Zone 0 is outside of all WPU polygons)
-        wpu = xr.where(wpu != 0, wpu, np.nan)
+        wpu = self._load_wpu_grid()
 
         logging.info("Calculating WPU veg type sums.")
         ds = xr.open_dataset(self.netcdf_filepath)


### PR DESCRIPTION
This PR solves #169. It creates a new CSV called _wpu_hsi_habitat_units.csv summarizing the HSI/SI results by Habitat Units (HU) scores. Habitat Units are determined as the HSI/SI mean score multiplied by the area in km^2 used to calculate that specific score (counting non-NaN pixels dynamically). Below is an example of the summary CSV columns, which includes the HSI/SI mean score, its area in km^2, and the HU score.

<img width="1388" height="582" alt="image" src="https://github.com/user-attachments/assets/d78cdc6d-bfe3-4dbe-a5c9-b1b351d55cbb" />
